### PR TITLE
More error cases

### DIFF
--- a/ensure-no-std/src/lib.rs
+++ b/ensure-no-std/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 
+use core::marker::PhantomData;
+
 // TODO: ensure more things then just `Clone`.
 
 #[derive(derive_where::DeriveWhere)]
-#[derive_where(Clone; T)]
-pub struct Test<T>(T);
+#[derive_where(Clone)]
+pub struct Test<T>(PhantomData<T>);

--- a/non-msrv-tests/tests/util.rs
+++ b/non-msrv-tests/tests/util.rs
@@ -1,0 +1,38 @@
+use core::{
+	fmt,
+	fmt::{Debug, Formatter},
+	marker::PhantomData,
+};
+
+pub struct Wrapper<T = ()> {
+	data: i32,
+	hack: PhantomData<T>,
+}
+
+impl<T> Debug for Wrapper<T> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.data)
+	}
+}
+
+impl From<i32> for Wrapper<()> {
+	fn from(data: i32) -> Self {
+		Self {
+			data,
+			hack: PhantomData,
+		}
+	}
+}
+
+impl<T> PartialEq<i32> for Wrapper<T> {
+	fn eq(&self, other: &i32) -> bool {
+		&self.data == other
+	}
+}
+
+#[cfg(feature = "zeroize")]
+impl<T> zeroize_::Zeroize for Wrapper<T> {
+	fn zeroize(&mut self) {
+		self.data.zeroize();
+	}
+}

--- a/non-msrv-tests/tests/zeroize.rs
+++ b/non-msrv-tests/tests/zeroize.rs
@@ -1,10 +1,12 @@
-#![allow(dead_code)]
+#![cfg(feature = "zeroize")]
 
-#[cfg(feature = "zeroize")]
 extern crate zeroize_ as zeroize;
 
+mod util;
+
+use self::util::Wrapper;
+
 #[test]
-#[cfg(feature = "zeroize")]
 fn test_zeroize() {
 	use derive_where::DeriveWhere;
 
@@ -12,19 +14,19 @@ fn test_zeroize() {
 	use crate::zeroize::Zeroize;
 
 	#[derive(DeriveWhere)]
-	#[derive_where(Zeroize; T)]
-	struct Test1<T>(T);
+	#[derive_where(Zeroize)]
+	struct Test1<T>(Wrapper<T>);
 
-	let mut test = Test1(42);
+	let mut test = Test1(42.into());
 	test.zeroize();
 
 	assert_eq!(test.0, 0);
 
 	#[derive(DeriveWhere)]
-	#[derive_where(Zeroize(crate = "zeroize_"); T)]
-	struct Test2<T>(T);
+	#[derive_where(Zeroize(crate = "zeroize_"))]
+	struct Test2<T>(Wrapper<T>);
 
-	let mut test = Test2(42);
+	let mut test = Test2(42.into());
 	test.zeroize();
 
 	assert_eq!(test.0, 0);

--- a/src/attr/default.rs
+++ b/src/attr/default.rs
@@ -30,11 +30,7 @@ impl Default {
 				let mut impl_default = false;
 
 				for derive_where in derive_wheres {
-					if derive_where
-						.traits
-						.iter()
-						.any(|trait_| **trait_ == Trait::Default)
-					{
+					if derive_where.trait_(Trait::Default).is_some() {
 						impl_default = true;
 						break;
 					}

--- a/src/attr/field.rs
+++ b/src/attr/field.rs
@@ -48,6 +48,10 @@ impl FieldAttr {
 		debug_assert!(meta.path().is_ident(DERIVE_WHERE));
 
 		if let Meta::List(list) = meta {
+			if list.nested.is_empty() {
+				return Err(Error::empty(list.span()));
+			}
+
 			for nested_meta in &list.nested {
 				match nested_meta {
 					NestedMeta::Meta(meta) => {
@@ -60,7 +64,7 @@ impl FieldAttr {
 						#[cfg(feature = "zeroize")]
 						{
 							if meta.path().is_ident(Trait::Zeroize.as_str()) {
-								self.zeroize_fqs.add_attribute(meta)?;
+								self.zeroize_fqs.add_attribute(meta, derive_wheres)?;
 								continue;
 							}
 						}

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -147,6 +147,15 @@ impl Parse for DeriveWhere {
 	}
 }
 
+impl DeriveWhere {
+	/// Returns selected [`DeriveTrait`] if present.
+	pub fn trait_(&self, trait_: Trait) -> Option<&DeriveTrait> {
+		self.traits
+			.iter()
+			.find(|derive_trait| ***derive_trait == trait_)
+	}
+}
+
 /// Holds a single generic [type](Type) or [type with bound](PredicateType).
 pub enum Generic {
 	/// Generic type with custom [specified bounds](PredicateType).

--- a/src/attr/skip.rs
+++ b/src/attr/skip.rs
@@ -83,6 +83,10 @@ impl Skip {
 					Skip::Traits(traits) => traits,
 				};
 
+				if list.nested.is_empty() {
+					return Err(Error::option_empty(list.span()));
+				}
+
 				for nested_meta in &list.nested {
 					if let NestedMeta::Meta(Meta::Path(path)) = nested_meta {
 						let trait_ = Trait::from_path(path)?;

--- a/src/attr/variant.rs
+++ b/src/attr/variant.rs
@@ -48,6 +48,10 @@ impl VariantAttr {
 		debug_assert!(meta.path().is_ident(DERIVE_WHERE));
 
 		if let Meta::List(list) = meta {
+			if list.nested.is_empty() {
+				return Err(Error::empty(list.span()));
+			}
+
 			for nested_meta in &list.nested {
 				match nested_meta {
 					NestedMeta::Meta(meta) => {

--- a/src/attr/zeroize_fqs.rs
+++ b/src/attr/zeroize_fqs.rs
@@ -17,6 +17,8 @@ impl ZeroizeFqs {
 	pub fn add_attribute(&mut self, meta: &Meta) -> Result<()> {
 		debug_assert!(meta.path().is_ident(Trait::Zeroize.as_str()));
 
+		// TODO: don't allow `Zeroize(fqs)` if `Zeroize` isn't being implemented
+
 		match meta {
 			Meta::List(list) => {
 				for nested_meta in &list.nested {

--- a/src/data.rs
+++ b/src/data.rs
@@ -260,6 +260,15 @@ impl<'a> Data<'a> {
 			}
 	}
 
+	/// Returns `true` if any field is skipped with that [`Trait`].
+	pub fn skip(&self, trait_: &Trait) -> bool {
+		self.skip_inner.skip(trait_)
+			|| match self.fields() {
+				Either::Left(fields) => fields.skip(trait_),
+				Either::Right(_) => false,
+			}
+	}
+
 	/// Return a [`SimpleType`].
 	pub fn simple_type(&self) -> SimpleType {
 		match &self.type_ {

--- a/src/data/fields.rs
+++ b/src/data/fields.rs
@@ -146,6 +146,11 @@ impl<'a> Fields<'a> {
 		pattern
 	}
 
+	/// Returns `true` if any field is skipped with that [`Trait`].
+	pub fn skip(&self, trait_: &Trait) -> bool {
+		self.fields.iter().any(|field| field.skip(trait_))
+	}
+
 	/// Returns an [`Iterator`] over [`Field`]s.
 	pub fn iter_fields(
 		&'a self,

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,12 +19,22 @@ impl Error {
 		syn::Error::new(span, "empty `derive_where` found")
 	}
 
-	/// Unsupported item.
+	/// Item has no use-case because it's covered by standard `#[derive(..)]`.
 	pub fn item(span: Span) -> syn::Error {
 		syn::Error::new(
 			span,
 			"derive-where doesn't support items without generics, `skip` attributes or `enum`s \
 			 implementing `Default`, as this can already be handled by standard `#[derive(..)]`",
+		)
+	}
+
+	/// Using the same generic type parameters as the item is unsupported,
+	/// because it's covered by standard `#[derive(..)]`.
+	pub fn generics(span: Span) -> syn::Error {
+		syn::Error::new(
+			span,
+			"derive-where doesn't support items with the same generic type parameters as the \
+			 item, as this can already be handled by standard `#[derive(..)]`",
 		)
 	}
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,11 @@ impl Error {
 		syn::Error::new(span, "unexpected option syntax")
 	}
 
+	/// Unsupported empty attribute option.
+	pub fn option_empty(span: Span) -> syn::Error {
+		syn::Error::new(span, "empty attribute option found")
+	}
+
 	/// Missing sub-option for an option.
 	#[cfg(feature = "zeroize")]
 	pub fn option_required(span: Span, option: &str) -> syn::Error {
@@ -227,5 +232,14 @@ impl Error {
 			"Zeroize",
 		]
 		.join(", ")
+	}
+
+	/// Unsupported `Zeroize` option if [`Zeroize`](https://docs.rs/zeroize/1.4.3/zeroize/trait.Zeroize.html) isn't implemented.
+	#[cfg(feature = "zeroize")]
+	pub fn zeroize(span: Span) -> syn::Error {
+		syn::Error::new(
+			span,
+			"`Zeroize` option is only supported if `Zeroize` is being implemented",
+		)
 	}
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,12 @@
 //! Parses [`DeriveInput`] into something more useful.
 
 use proc_macro2::Span;
-use syn::{DeriveInput, Generics, Result};
+use syn::{DeriveInput, GenericParam, Generics, Result, Type, TypePath};
 
-use crate::{Data, Default, DeriveWhere, Either, Error, Item, ItemAttr, Trait, VariantAttr};
+use crate::{
+	Data, Default, DeriveTrait, DeriveWhere, Either, Error, Generic, Item, ItemAttr, Trait,
+	VariantAttr,
+};
 
 /// Parsed input.
 pub struct Input<'a> {
@@ -79,12 +82,10 @@ impl<'a> Input<'a> {
 				// Make sure a variant has the `option` attribute if `Default` is being
 				// implemented.
 				if !accumulated_defaults.0
-					&& derive_wheres.iter().any(|derive_where| {
-						derive_where
-							.traits
-							.iter()
-							.any(|trait_| **trait_ == Trait::Default)
-					}) {
+					&& derive_wheres
+						.iter()
+						.any(|derive_where| derive_where.trait_(Trait::Default).is_some())
+				{
 					return Err(Error::default_missing(span));
 				}
 
@@ -98,33 +99,126 @@ impl<'a> Input<'a> {
 
 		// TODO: don't allow generic constraints be the same as generics on item.
 
+		// Don't allow no use-case compared to std `derive`.
+		let mut found_use_case = false;
+		// Any generics used.
+		found_use_case |= generics
+			.params
+			.iter()
+			.any(|generic_param| match generic_param {
+				GenericParam::Type(_) => true,
+				GenericParam::Lifetime(_) | GenericParam::Const(_) => false,
+			});
+		// Any field is skipped.
+		found_use_case |= item.any_skip();
+		// `Default` is used on an enum.
+		found_use_case |= item.any_default(&derive_wheres);
 		#[cfg(feature = "zeroize")]
 		{
-			if !(
-				// Any generics used.
-				!generics.params.is_empty()
-                // Any field is skipped.
-                || item.any_skip()
-                // `Default` is used on an enum.
-                || item.any_default(&derive_wheres)
-                // `Zeroize(fqs)` is used on any field.
-                || item.any_fqs()
-			) {
-				return Err(Error::item(span));
-			}
+			// `Zeroize(crate = "..")` is used.
+			found_use_case |= derive_wheres.iter().any(|derive_where| {
+				#[allow(clippy::match_like_matches_macro)]
+				{
+					if let Some(DeriveTrait::Zeroize {
+						crate_: Some(_), ..
+					}) = derive_where.trait_(Trait::Zeroize)
+					{
+						true
+					} else {
+						false
+					}
+				}
+			});
+			// `Zeroize(fqs)` is used on any field.
+			found_use_case |= item.any_fqs();
 		}
 
-		#[cfg(not(feature = "zeroize"))]
-		{
-			if !(
-				// Any generics used.
-				!generics.params.is_empty()
-                // Any field is skipped.
-                || item.any_skip()
-                // `Default` is used on an enum.
-                || item.any_default(&derive_wheres)
-			) {
-				return Err(Error::item(span));
+		if !found_use_case {
+			return Err(Error::item(span));
+		}
+
+		// Don't allow generic constraints be the same as generics on item unless there
+		// is a use-case for it.
+		// Count number of generic type parameters.
+		let generics_len = generics
+			.params
+			.iter()
+			.filter(|generic_param| match generic_param {
+				GenericParam::Type(_) => true,
+				GenericParam::Lifetime(_) | GenericParam::Const(_) => false,
+			})
+			.count();
+
+		'outer: for derive_where in &derive_wheres {
+			// No point in starting to compare both if not even the length is the same.
+			if derive_where.generics.len() != generics_len {
+				continue;
+			}
+
+			// No point in starting to check if there is no use-case if a custom bound was
+			// used, which is a use-case.
+			if derive_where.generics.iter().any(|generic| match generic {
+				Generic::CoustomBound(_) => true,
+				Generic::NoBound(_) => false,
+			}) {
+				continue;
+			}
+
+			// Check if every generic type parameter present on the item is defined in this
+			// `DeriveWhere`.
+			for generic_param in &generics.params {
+				// Only check generic type parameters.
+				if let GenericParam::Type(type_param) = generic_param {
+					if !derive_where.generics.iter().any(|generic| match generic {
+						Generic::NoBound(Type::Path(TypePath { qself: None, path })) => {
+							if let Some(ident) = path.get_ident() {
+								ident == &type_param.ident
+							} else {
+								false
+							}
+						}
+						Generic::NoBound(_) => false,
+						_ => unreachable!("earlier check for custom bounds failed"),
+					}) {
+						continue 'outer;
+					}
+				}
+			}
+
+			// The `for` loop should short-circuit to the `'outer` loop if not all generic
+			// type parameters were found.
+
+			// Make sure we aren't using any other features.
+			let mut found_use_case = false;
+			// `Default` is used on an enum.
+			found_use_case |= match item {
+				Item::Enum { .. } => derive_where.trait_(Trait::Default).is_some(),
+				Item::Item(_) => false,
+			};
+			// Any field is skipped with a corresponding `Trait`.
+			found_use_case |= derive_where.traits.iter().any(|trait_| item.skip(trait_));
+			#[cfg(feature = "zeroize")]
+			{
+				// `Zeroize(crate = "..")` is used.
+				found_use_case |= {
+					#[allow(clippy::match_like_matches_macro)]
+					{
+						if let Some(DeriveTrait::Zeroize {
+							crate_: Some(_), ..
+						}) = derive_where.trait_(Trait::Zeroize)
+						{
+							true
+						} else {
+							false
+						}
+					}
+				};
+				// ).is_some(); `Zeroize(fqs)` is used on any field.
+				found_use_case |= derive_where.trait_(Trait::Zeroize).is_some() && item.any_fqs();
+			}
+
+			if !found_use_case {
+				return Err(Error::generics(span));
 			}
 		}
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,9 +3,10 @@
 use proc_macro2::Span;
 use syn::{DeriveInput, GenericParam, Generics, Result, Type, TypePath};
 
+#[cfg(feature = "zeroize")]
+use crate::DeriveTrait;
 use crate::{
-	Data, Default, DeriveTrait, DeriveWhere, Either, Error, Generic, Item, ItemAttr, Trait,
-	VariantAttr,
+	Data, Default, DeriveWhere, Either, Error, Generic, Item, ItemAttr, Trait, VariantAttr,
 };
 
 /// Parsed input.

--- a/src/input.rs
+++ b/src/input.rs
@@ -98,8 +98,6 @@ impl<'a> Input<'a> {
 			}
 		};
 
-		// TODO: don't allow generic constraints be the same as generics on item.
-
 		// Don't allow no use-case compared to std `derive`.
 		let mut found_use_case = false;
 		// Any generics used.
@@ -214,12 +212,12 @@ impl<'a> Input<'a> {
 						}
 					}
 				};
-				// ).is_some(); `Zeroize(fqs)` is used on any field.
+				// `Zeroize(fqs)` is used on any field.
 				found_use_case |= derive_where.trait_(Trait::Zeroize).is_some() && item.any_fqs();
 			}
 
 			if !found_use_case {
-				return Err(Error::generics(span));
+				return Err(Error::generics(derive_where.span));
 			}
 		}
 

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -7,12 +7,11 @@ use super::test_derive;
 fn struct_() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd; T)]
-			struct Test<T> { field: T }
+			#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+			struct Test<T> { field: core::marker::PhatomData<T> }
 		},
 		quote! {
 			impl<T> ::core::clone::Clone for Test<T>
-			where T: ::core::clone::Clone
 			{
 				#[inline]
 				fn clone(&self) -> Self {
@@ -23,11 +22,9 @@ fn struct_() -> Result<()> {
 			}
 
 			impl<T> ::core::marker::Copy for Test<T>
-			where T: ::core::marker::Copy
 			{ }
 
 			impl<T> ::core::fmt::Debug for Test<T>
-			where T: ::core::fmt::Debug
 			{
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -41,7 +38,6 @@ fn struct_() -> Result<()> {
 			}
 
 			impl<T> ::core::default::Default for Test<T>
-			where T: ::core::default::Default
 			{
 				fn default() -> Self {
 					Test { field: ::core::default::Default::default() }
@@ -49,11 +45,9 @@ fn struct_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::Eq for Test<T>
-			where T: ::core::cmp::Eq
 			{ }
 
 			impl<T> ::core::hash::Hash for Test<T>
-			where T: ::core::hash::Hash
 			{
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
@@ -63,7 +57,6 @@ fn struct_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::Ord for Test<T>
-			where T: ::core::cmp::Ord
 			{
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -78,7 +71,6 @@ fn struct_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -90,7 +82,6 @@ fn struct_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -111,12 +102,11 @@ fn struct_() -> Result<()> {
 fn tuple() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd; T)]
-			struct Test<T>(T);
+			#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+			struct Test<T>(core::marker::PhatomData<T>);
 		},
 		quote! {
 			impl<T> ::core::clone::Clone for Test<T>
-			where T: ::core::clone::Clone
 			{
 				#[inline]
 				fn clone(&self) -> Self {
@@ -127,11 +117,9 @@ fn tuple() -> Result<()> {
 			}
 
 			impl<T> ::core::marker::Copy for Test<T>
-			where T: ::core::marker::Copy
 			{ }
 
 			impl<T> ::core::fmt::Debug for Test<T>
-			where T: ::core::fmt::Debug
 			{
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -145,7 +133,6 @@ fn tuple() -> Result<()> {
 			}
 
 			impl<T> ::core::default::Default for Test<T>
-			where T: ::core::default::Default
 			{
 				fn default() -> Self {
 					Test(::core::default::Default::default())
@@ -153,11 +140,9 @@ fn tuple() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::Eq for Test<T>
-			where T: ::core::cmp::Eq
 			{ }
 
 			impl<T> ::core::hash::Hash for Test<T>
-			where T: ::core::hash::Hash
 			{
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
@@ -167,7 +152,6 @@ fn tuple() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::Ord for Test<T>
-			where T: ::core::cmp::Ord
 			{
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -182,7 +166,6 @@ fn tuple() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -194,7 +177,6 @@ fn tuple() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -339,11 +321,11 @@ fn enum_() -> Result<()> {
 
 	test_derive(
 		quote! {
-			#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd; T)]
+			#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 			enum Test<T> {
-				A { field: T},
+				A { field: core::marker::PhatomData<T>},
 				B { },
-				C(T),
+				C(core::marker::PhatomData<T>),
 				D(),
 				#[derive_where(default)]
 				E,
@@ -351,7 +333,6 @@ fn enum_() -> Result<()> {
 		},
 		quote! {
 			impl<T> ::core::clone::Clone for Test<T>
-			where T: ::core::clone::Clone
 			{
 				#[inline]
 				fn clone(&self) -> Self {
@@ -366,11 +347,9 @@ fn enum_() -> Result<()> {
 			}
 
 			impl<T> ::core::marker::Copy for Test<T>
-			where T: ::core::marker::Copy
 			{ }
 
 			impl<T> ::core::fmt::Debug for Test<T>
-			where T: ::core::fmt::Debug
 			{
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -398,7 +377,6 @@ fn enum_() -> Result<()> {
 			}
 
 			impl<T> ::core::default::Default for Test<T>
-			where T: ::core::default::Default
 			{
 				fn default() -> Self {
 					Test::E
@@ -406,11 +384,9 @@ fn enum_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::Eq for Test<T>
-			where T: ::core::cmp::Eq
 			{ }
 
 			impl<T> ::core::hash::Hash for Test<T>
-			where T: ::core::hash::Hash
 			{
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
@@ -436,7 +412,6 @@ fn enum_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::Ord for Test<T>
-			where T: ::core::cmp::Ord
 			{
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -463,7 +438,6 @@ fn enum_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -482,7 +456,6 @@ fn enum_() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -515,7 +488,7 @@ fn enum_() -> Result<()> {
 fn union_() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Clone, Copy; T)]
+			#[derive_where(Clone, Copy)]
 			union Test<T> {
 				a: core::marker::PhantomData<T>,
 				b: u8,
@@ -523,7 +496,6 @@ fn union_() -> Result<()> {
 		},
 		quote! {
 			impl<T> ::core::clone::Clone for Test<T>
-			where T: ::core::clone::Clone + ::core::marker::Copy
 			{
 				#[inline]
 				fn clone(&self) -> Self {
@@ -534,7 +506,6 @@ fn union_() -> Result<()> {
 			}
 
 			impl<T> ::core::marker::Copy for Test<T>
-			where T: ::core::marker::Copy
 			{ }
 		},
 	)

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -4,14 +4,15 @@ use syn::Result;
 use super::test_derive;
 
 #[test]
-fn no_bound() -> Result<()> {
+fn bound() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Clone)]
-			struct Test<T>(u8, core::marker::PhantomData<T>);
+			#[derive_where(Clone; T)]
+			struct Test<T, U>(T, core::marker::PhantomData<U>);
 		},
 		quote! {
-			impl<T> ::core::clone::Clone for Test<T>
+			impl<T, U> ::core::clone::Clone for Test<T, U>
+			where T: ::core::clone::Clone
 			{
 				#[inline]
 				fn clone(&self) -> Self {
@@ -25,14 +26,17 @@ fn no_bound() -> Result<()> {
 }
 
 #[test]
-fn no_bound_multiple() -> Result<()> {
+fn bound_multiple() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Clone, Copy)]
-			struct Test<T>(u8, core::marker::PhantomData<T>);
+			#[derive_where(Clone; T, U)]
+			struct Test<T, U, V>((T, U), core::marker::PhantomData<V>);
 		},
 		quote! {
-			impl<T> ::core::clone::Clone for Test<T>
+			impl<T, U, V> ::core::clone::Clone for Test<T, U, V>
+			where
+				T: ::core::clone::Clone,
+				U: ::core::clone::Clone
 			{
 				#[inline]
 				fn clone(&self) -> Self {
@@ -41,8 +45,6 @@ fn no_bound_multiple() -> Result<()> {
 					}
 				}
 			}
-
-			impl<T> ::core::marker::Copy for Test<T> { }
 		},
 	)
 }
@@ -74,10 +76,10 @@ fn where_() -> Result<()> {
 	test_derive(
 		quote! {
 			#[derive_where(Clone; T)]
-			struct Test<T>(T) where T: core::fmt::Debug;
+			struct Test<T, U>(T, core::marker::PhantomData<U>) where T: core::fmt::Debug;
 		},
 		quote! {
-			impl<T> ::core::clone::Clone for Test<T>
+			impl<T, U> ::core::clone::Clone for Test<T, U>
 			where
 				T: core::fmt::Debug,
 				T: ::core::clone::Clone
@@ -85,7 +87,7 @@ fn where_() -> Result<()> {
 				#[inline]
 				fn clone(&self) -> Self {
 					match self {
-						Test(ref __0) => Test(::core::clone::Clone::clone(__0)),
+						Test(ref __0, ref __1) => Test(::core::clone::Clone::clone(__0), ::core::clone::Clone::clone(__1)),
 					}
 				}
 			}

--- a/src/test/enum_.rs
+++ b/src/test/enum_.rs
@@ -74,12 +74,11 @@ fn enum_default_unit() -> Result<()> {
 fn enum_one_data() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(PartialEq, PartialOrd; T)]
-			enum Test<T> { A(T) }
+			#[derive_where(PartialEq, PartialOrd)]
+			enum Test<T> { A(core::marker::PhantomData<T>) }
 		},
 		quote! {
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -91,7 +90,6 @@ fn enum_one_data() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -153,12 +151,11 @@ fn enum_two_data() -> Result<()> {
 
 	test_derive(
 		quote! {
-			#[derive_where(PartialEq, PartialOrd; T)]
-			enum Test<T> { A(T), B(T) }
+			#[derive_where(PartialEq, PartialOrd)]
+			enum Test<T> { A(core::marker::PhantomData<T>), B(core::marker::PhantomData<T>) }
 		},
 		quote! {
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -177,7 +174,6 @@ fn enum_two_data() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -247,12 +243,11 @@ fn enum_unit() -> Result<()> {
 
 	test_derive(
 		quote! {
-			#[derive_where(PartialEq, PartialOrd; T)]
-			enum Test<T> { A(T), B }
+			#[derive_where(PartialEq, PartialOrd)]
+			enum Test<T> { A(core::marker::PhantomData<T>), B }
 		},
 		quote! {
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -269,7 +264,6 @@ fn enum_unit() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -334,12 +328,11 @@ fn enum_struct_unit() -> Result<()> {
 
 	test_derive(
 		quote! {
-			#[derive_where(PartialEq, PartialOrd; T)]
-			enum Test<T> { A(T), B { } }
+			#[derive_where(PartialEq, PartialOrd)]
+			enum Test<T> { A(core::marker::PhantomData<T>), B { } }
 		},
 		quote! {
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -356,7 +349,6 @@ fn enum_struct_unit() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -421,12 +413,11 @@ fn enum_tuple_unit() -> Result<()> {
 
 	test_derive(
 		quote! {
-			#[derive_where(PartialEq, PartialOrd; T)]
-			enum Test<T> { A(T), B() }
+			#[derive_where(PartialEq, PartialOrd)]
+			enum Test<T> { A(core::marker::PhantomData<T>), B() }
 		},
 		quote! {
 			impl<T> ::core::cmp::PartialEq for Test<T>
-			where T: ::core::cmp::PartialEq
 			{
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -443,7 +434,6 @@ fn enum_tuple_unit() -> Result<()> {
 			}
 
 			impl<T> ::core::cmp::PartialOrd for Test<T>
-			where T: ::core::cmp::PartialOrd
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {

--- a/src/test/zeroize.rs
+++ b/src/test/zeroize.rs
@@ -7,12 +7,11 @@ use super::test_derive;
 fn zeroize() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Zeroize; T)]
-			struct Test<T>(T);
+			#[derive_where(Zeroize)]
+			struct Test<T>(core::marker::PhantomData<T>);
 		},
 		quote! {
 			impl<T> ::zeroize::Zeroize for Test<T>
-			where T: ::zeroize::Zeroize
 			{
 				fn zeroize(&mut self) {
 					match self {
@@ -31,22 +30,23 @@ fn zeroize_drop() -> Result<()> {
 	test_derive(
 		quote! {
 			#[derive_where(Zeroize(drop); T)]
-			struct Test<T>(T);
+			struct Test<T, U>(T, core::marker::PhantomData<U>);
 		},
 		quote! {
-			impl<T> ::zeroize::Zeroize for Test<T>
+			impl<T, U> ::zeroize::Zeroize for Test<T, U>
 			where T: ::zeroize::Zeroize
 			{
 				fn zeroize(&mut self) {
 					match self {
-						Test(ref mut __0) => {
+						Test(ref mut __0, ref mut __1) => {
 							__0.zeroize();
+							__1.zeroize();
 						}
 					}
 				}
 			}
 
-			impl<T> ::core::ops::Drop for Test<T>
+			impl<T, U> ::core::ops::Drop for Test<T, U>
 			where T: ::zeroize::Zeroize
 			{
 				fn drop(&mut self) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::clone_on_copy)]
 
+mod util;
+
 use core::{
 	fmt::Debug,
 	hash::{Hash, Hasher},
@@ -7,6 +9,8 @@ use core::{
 use std::collections::hash_map::DefaultHasher;
 
 use derive_where::DeriveWhere;
+
+use self::util::Wrapper;
 
 struct AssertClone<T: Clone>(T);
 struct AssertCopy<T: Copy>(T);
@@ -20,13 +24,13 @@ struct AssertPartialOrd<T: PartialOrd>(T);
 #[test]
 fn struct_single() {
 	#[derive(DeriveWhere)]
-	#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd; T)]
+	#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 	struct Test<T> {
-		a: T,
+		a: Wrapper<T>,
 	}
 
-	let test_1 = Test { a: 42 };
-	let test_2 = Test { a: 42 };
+	let test_1 = Test { a: 42.into() };
+	let test_2 = Test { a: 42.into() };
 
 	let _ = AssertClone(test_1);
 	let _ = AssertCopy(test_1);
@@ -57,31 +61,31 @@ fn struct_single() {
 	assert_eq!(hash_1, hash_2);
 
 	assert!(test_1 == test_2);
-	assert!(test_1 != Test { a: 43 });
+	assert!(test_1 != Test { a: 43.into() });
 
-	assert!(test_1 > Test { a: 41 });
-	assert!(test_1 < Test { a: 43 });
+	assert!(test_1 > Test { a: 41.into() });
+	assert!(test_1 < Test { a: 43.into() });
 }
 
 #[test]
 fn struct_multiple() {
 	#[derive(DeriveWhere)]
-	#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd; T)]
+	#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 	struct Test<T> {
-		a: T,
-		b: T,
-		c: T,
+		a: Wrapper<T>,
+		b: Wrapper<T>,
+		c: Wrapper<T>,
 	}
 
 	let test_1 = Test {
-		a: 42,
-		b: 43,
-		c: 44,
+		a: 42.into(),
+		b: 43.into(),
+		c: 44.into(),
 	};
 	let test_2 = Test {
-		a: 42,
-		b: 43,
-		c: 44,
+		a: 42.into(),
+		b: 43.into(),
+		c: 44.into(),
 	};
 
 	let _ = AssertClone(test_1);
@@ -122,82 +126,82 @@ fn struct_multiple() {
 	assert!(
 		test_1
 			!= Test {
-				a: 43,
-				b: 43,
-				c: 44
+				a: 43.into(),
+				b: 43.into(),
+				c: 44.into(),
 			}
 	);
 	assert!(
 		test_1
 			!= Test {
-				a: 42,
-				b: 44,
-				c: 44
+				a: 42.into(),
+				b: 44.into(),
+				c: 44.into(),
 			}
 	);
 	assert!(
 		test_1
 			!= Test {
-				a: 42,
-				b: 43,
-				c: 45
+				a: 42.into(),
+				b: 43.into(),
+				c: 45.into(),
 			}
 	);
 	assert!(
 		test_1
 			!= Test {
-				a: 45,
-				b: 45,
-				c: 45
+				a: 45.into(),
+				b: 45.into(),
+				c: 45.into(),
 			}
 	);
 
 	assert!(
 		test_1
 			> Test {
-				a: 41,
-				b: 43,
-				c: 44
+				a: 41.into(),
+				b: 43.into(),
+				c: 44.into(),
 			}
 	);
 	assert!(
 		test_1
 			> Test {
-				a: 42,
-				b: 42,
-				c: 44
+				a: 42.into(),
+				b: 42.into(),
+				c: 44.into(),
 			}
 	);
 	assert!(
 		test_1
 			> Test {
-				a: 42,
-				b: 43,
-				c: 43
+				a: 42.into(),
+				b: 43.into(),
+				c: 43.into(),
 			}
 	);
 	assert!(
 		test_1
 			< Test {
-				a: 43,
-				b: 43,
-				c: 44
+				a: 43.into(),
+				b: 43.into(),
+				c: 44.into(),
 			}
 	);
 	assert!(
 		test_1
 			< Test {
-				a: 42,
-				b: 44,
-				c: 44
+				a: 42.into(),
+				b: 44.into(),
+				c: 44.into(),
 			}
 	);
 	assert!(
 		test_1
 			< Test {
-				a: 42,
-				b: 43,
-				c: 45
+				a: 42.into(),
+				b: 43.into(),
+				c: 45.into(),
 			}
 	);
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,79 @@
+use core::{
+	cmp::Ordering,
+	fmt,
+	fmt::{Debug, Formatter},
+	hash::{Hash, Hasher},
+	marker::PhantomData,
+};
+
+pub struct Wrapper<T = ()> {
+	data: i32,
+	hack: PhantomData<T>,
+}
+
+impl<T> Clone for Wrapper<T> {
+	fn clone(&self) -> Self {
+		Self {
+			data: self.data,
+			hack: self.hack,
+		}
+	}
+}
+
+impl<T> Copy for Wrapper<T> {}
+
+impl<T> Debug for Wrapper<T> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.data)
+	}
+}
+
+impl<T> Default for Wrapper<T> {
+	fn default() -> Self {
+		Self {
+			data: i32::default(),
+			hack: PhantomData,
+		}
+	}
+}
+
+impl<T> Eq for Wrapper<T> {}
+
+impl From<i32> for Wrapper<()> {
+	fn from(data: i32) -> Self {
+		Self {
+			data,
+			hack: PhantomData,
+		}
+	}
+}
+
+impl<T> Hash for Wrapper<T> {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.data.hash(state);
+	}
+}
+
+impl<T> Ord for Wrapper<T> {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.data.cmp(&other.data)
+	}
+}
+
+impl<T> PartialEq for Wrapper<T> {
+	fn eq(&self, other: &Self) -> bool {
+		self.data == other.data
+	}
+}
+
+impl<T> PartialEq<i32> for Wrapper<T> {
+	fn eq(&self, other: &i32) -> bool {
+		&self.data == other
+	}
+}
+
+impl<T> PartialOrd for Wrapper<T> {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		self.data.partial_cmp(&other.data)
+	}
+}


### PR DESCRIPTION
A couple more remaining error case, a big one I just implemented is to check if the generics to bind are the same as the ones specified on the item itself.
```rust
#[derive_where(Clone; T)]
struct Test<T>(T);
```
Doesn't work anymore, this can be done with the standard `derive`.