### PR TITLE
Implement `ZeroizeOnDrop`

### DIFF
--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,4 +1,4 @@
-11
+13
 Changelog
 CHANGELOG
 destructure/G
@@ -10,3 +10,5 @@ std's
 struct/S
 TODO
 tuple
+v1
+zeroize

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,12 @@ jobs:
           - { channel: stable, features: --features safe }
           - { channel: nightly, features: --features nightly }
           - { channel: stable, features: --features zeroize }
+          - { channel: stable, features: --features zeroize-on-drop }
           - { channel: nightly, features: --features safe,nightly }
           - { channel: stable, features: --features safe,zeroize }
+          - { channel: stable, features: --features safe,zeroize-on-drop }
           - { channel: nightly, features: --features nightly,zeroize }
+          - { channel: nightly, features: --features nightly,zeroize-on-drop }
           - { channel: nightly, features: --all-features }
 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,18 @@ jobs:
           - ""
           - --features safe
           - --features zeroize
+          - --features zeroize-on-drop
           - --features safe,zeroize
+          - --features safe,zeroize-on-drop
         exclude:
           - rust: { version: 1.34.2, workspace: "" }
             features: --features zeroize
           - rust: { version: 1.34.2, workspace: "" }
+            features: --features zeroize-on-drop
+          - rust: { version: 1.34.2, workspace: "" }
             features: --features safe,zeroize
+          - rust: { version: 1.34.2, workspace: "" }
+            features: --features safe,zeroize-on-drop
         include:
           - rust: { version: nightly, workspace: "--workspace" }
             features: --features nightly
@@ -30,6 +36,8 @@ jobs:
             features: --features safe,nightly
           - rust: { version: nightly, workspace: "--workspace" }
             features: --features nightly,zeroize
+          - rust: { version: nightly, workspace: "--workspace" }
+            features: --features nightly,zeroize-on-drop
           - rust: { version: nightly, workspace: "--workspace" }
             features: --all-features
 
@@ -66,12 +74,18 @@ jobs:
           - ""
           - --features safe
           - --features zeroize
+          - --features zeroize-on-drop
           - --features safe,zeroize
+          - --features safe,zeroize-on-drop
         exclude:
           - rust: 1.34.2
             features: --features zeroize
           - rust: 1.34.2
+            features: --features zeroize-on-drop
+          - rust: 1.34.2
             features: --features safe,zeroize
+          - rust: 1.34.2
+            features: --features safe,zeroize-on-drop
         include:
           - rust: nightly
             features: --features nightly
@@ -79,6 +93,8 @@ jobs:
             features: --features safe,nightly
           - rust: nightly
             features: --features nightly,zeroize
+          - rust: nightly
+            features: --features nightly,zeroize-on-drop
           - rust: nightly
             features: --all-features
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     # Give nightly release some time to complete.
     # See <https://github.com/rust-lang/rustup-components-history/blob/dc6890bde289ac72d9d16959e4432f72f30c051b/.github/workflows/rust.yml#L9-L10>
-    - cron:  '0 2 * * *'
+    - cron: 0 2 * * *
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support `ZeroizeOnDrop`.
+- Support [`ZeroizeOnDrop`](https://docs.rs/zeroize/1.5.0-pre/zeroize/trait.ZeroizeOnDrop.html).
 
 ### Removed
 - **Breaking Change**: Remove support for `Zeroize(drop)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support `ZeroizeOnDrop`.
+
+### Removed
+- **Breaking Change**: Remove support for `Zeroize(drop)`.
 
 ## [1.0.0-rc.1] - 2021-12-08
 ### Added
 - Initial release.
 
+[Unreleased]: https://github.com/ModProg/derive-where/compare/v1.0.0-rc.1...HEAD
 [1.0.0-rc.1]: https://github.com/ModProg/derive-where/releases/tag/v1.0.0-rc.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ syn = { version = "1", default-features = false, features = [
 [dev-dependencies]
 syn = { version = "1", default-features = false, features = ["extra-traits"] }
 
+[patch.crates-io]
+zeroize = { git = "https://github.com/khonsulabs/utils", branch = "zeroize-on-drop-auto-deref" }
+
 [[test]]
 name = "util"
 path = "tests/util.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "derive-where"
 readme = "README.md"
 repository = "https://github.com/ModProg/derive-where"
 rust-version = "1.34.2"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 
 [lib]
 proc-macro = true
@@ -24,6 +24,7 @@ proc-macro = true
 nightly = []
 safe = []
 zeroize = []
+zeroize-on-drop = ["zeroize"]
 
 [dependencies]
 proc-macro2 = { version = "1", default-features = false, features = ["proc-macro"] }
@@ -38,9 +39,6 @@ syn = { version = "1", default-features = false, features = [
 
 [dev-dependencies]
 syn = { version = "1", default-features = false, features = ["extra-traits"] }
-
-[patch.crates-io]
-zeroize = { git = "https://github.com/khonsulabs/utils", branch = "zeroize-on-drop-auto-deref" }
 
 [[test]]
 name = "util"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ assert_eq!(test.0, 0);
 
 ### `ZeroizeOnDrop` options
 
+If the `zeroize-on-drop` feature is enabled, it implements [`ZeroizeOnDrop`]
+and can be implemented without [`Zeroize`], otherwise it only implements
+[`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html) and requires [`Zeroize`] to be implemented.
+
 [`ZeroizeOnDrop`] has one option:
 - `crate`: an item-level option which specifies a path to the `zeroize`
   crate in case of a re-export or rename.
@@ -206,7 +210,9 @@ The following traits can be derived with derive-where:
 - [`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html)
 - [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html)
 - [`Zeroize`]: Only available with the `zeroize` crate feature.
-- [`ZeroizeOnDrop`]: Only available with the `zeroize` crate feature.
+- [`ZeroizeOnDrop`]: Only available with the `zeroize` crate feature. If the
+  `zeroize-on-drop` feature is enabled, it implements [`ZeroizeOnDrop`],
+  otherwise it only implements [`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html).
 
 ### Supported items
 
@@ -233,7 +239,9 @@ Unions only support [`Clone`](https://doc.rust-lang.org/core/clone/trait.Clone.h
   replaces all cases of [`core::hint::unreachable_unchecked`](https://doc.rust-lang.org/core/hint/fn.unreachable_unchecked.html) in [`Ord`](https://doc.rust-lang.org/core/hint/fn.unreachable_unchecked.html),
   [`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html) and [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html), which is what std uses, with
   [`unreachable`](https://doc.rust-lang.org/core/macro.unreachable.html).
-- `zeroize`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`].
+- `zeroize`: Allows deriving [`Zeroize`] and [`method@zeroize`] on [`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html).
+- `zeroize-on-drop`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`] and
+  requires [zeroize] v1.5.0-pre.
 
 ## MSRV
 
@@ -271,10 +279,11 @@ conditions.
 [CHANGELOG]: https://github.com/ModProg/derive-where/blob/main/CHANGELOG.md
 [LICENSE-MIT]: https://github.com/ModProg/derive-where/blob/main/LICENSE-MIT
 [LICENSE-APACHE]: https://github.com/ModProg/derive-where/blob/main/LICENSE-APACHE
+[zeroize]: https://crates.io/crates/zeroize/1.5.0-pre
 [`Debug`]: https://doc.rust-lang.org/core/fmt/trait.Debug.html
 [`Default`]: https://doc.rust-lang.org/core/default/trait.Default.html
 [`Hash`]: https://doc.rust-lang.org/core/hash/trait.Hash.html
 [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
-[`ZeroizeOnDrop`]: https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html
+[`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5.0-pre/zeroize/trait.ZeroizeOnDrop.html
 [`method@zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
 [#27]: https://github.com/ModProg/derive-where/issues/27

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ enum Example<T> {
 
 With a `skip` or `skip_inner` attribute fields can be skipped for traits
 that allow it, which are: [`Debug`], [`Hash`], [`Ord`](https://doc.rust-lang.org/core/cmp/trait.Ord.html), [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html),
-[`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html) and [`Zeroize`].
+[`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html), [`Zeroize`] and [`ZeroizeOnDrop`].
 
 ```rust
 #[derive(DeriveWhere)]
@@ -148,18 +148,16 @@ assert_ne!(
 
 ### `Zeroize` options
 
-[`Zeroize`] has three options:
+[`Zeroize`] has two options:
 - `crate`: an item-level option which specifies a path to the `zeroize`
   crate in case of a re-export or rename.
-- `drop`: an item-level option which implements [`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html) and uses
-  [`Zeroize`] to erase all data from memory.
 - `fqs`: a field -level option which will use fully-qualified-syntax instead
   of calling the [`zeroize`][`method@zeroize`] method on `self` directly.
   This is to avoid ambiguity between another method also called `zeroize`.
 
 ```rust
 #[derive(DeriveWhere)]
-#[derive_where(Zeroize(crate = "zeroize_", drop))]
+#[derive_where(Zeroize(crate = "zeroize_"))]
 struct Example(#[derive_where(Zeroize(fqs))] i32);
 
 impl Example {
@@ -181,6 +179,20 @@ Zeroize::zeroize(&mut test);
 assert_eq!(test.0, 0);
 ```
 
+### `ZeroizeOnDrop` options
+
+[`ZeroizeOnDrop`] has one option:
+- `crate`: an item-level option which specifies a path to the `zeroize`
+  crate in case of a re-export or rename.
+
+```
+#[derive(DeriveWhere)]
+#[derive_where(ZeroizeOnDrop(crate = "zeroize_"))]
+struct Example(i32);
+
+assert!(core::mem::needs_drop::<Example>());
+```
+
 ### Supported traits
 
 The following traits can be derived with derive-where:
@@ -194,6 +206,7 @@ The following traits can be derived with derive-where:
 - [`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html)
 - [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html)
 - [`Zeroize`]: Only available with the `zeroize` crate feature.
+- [`ZeroizeOnDrop`]: Only available with the `zeroize` crate feature.
 
 ### Supported items
 
@@ -220,7 +233,7 @@ Unions only support [`Clone`](https://doc.rust-lang.org/core/clone/trait.Clone.h
   replaces all cases of [`core::hint::unreachable_unchecked`](https://doc.rust-lang.org/core/hint/fn.unreachable_unchecked.html) in [`Ord`](https://doc.rust-lang.org/core/hint/fn.unreachable_unchecked.html),
   [`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html) and [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html), which is what std uses, with
   [`unreachable`](https://doc.rust-lang.org/core/macro.unreachable.html).
-- `zeroize`: Allows deriving [`Zeroize`].
+- `zeroize`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`].
 
 ## MSRV
 
@@ -262,5 +275,6 @@ conditions.
 [`Default`]: https://doc.rust-lang.org/core/default/trait.Default.html
 [`Hash`]: https://doc.rust-lang.org/core/hash/trait.Hash.html
 [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
+[`ZeroizeOnDrop`]: https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html
 [`method@zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
 [#27]: https://github.com/ModProg/derive-where/issues/27

--- a/ensure-no-std/Cargo.toml
+++ b/ensure-no-std/Cargo.toml
@@ -8,10 +8,11 @@ version = "0.0.0"
 nightly = ["derive-where/nightly"]
 safe = ["derive-where/safe"]
 zeroize = ["derive-where/zeroize", "zeroize_"]
+zeroize-on-drop = ["derive-where/zeroize-on-drop", "zeroize"]
 
 [dependencies]
 derive-where = { path = ".." }
-zeroize_ = { version = "1", package = "zeroize", default-features = false, optional = true }
+zeroize_ = { version = "1.5.0-pre", package = "zeroize", default-features = false, optional = true }
 
 [lib]
 doctest = false

--- a/ensure-no-std/src/lib.rs
+++ b/ensure-no-std/src/lib.rs
@@ -10,4 +10,4 @@ use derive_where::DeriveWhere;
 #[derive(DeriveWhere)]
 #[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "zeroize", derive_where(Zeroize))]
-pub struct Test<T>(#[cfg_attr(feature = "zeroize", derive_where(skip(Zeroize)))] PhantomData<T>);
+pub struct Test<T>(PhantomData<T>);

--- a/non-msrv-tests/Cargo.toml
+++ b/non-msrv-tests/Cargo.toml
@@ -8,13 +8,14 @@ version = "0.0.0"
 nightly = ["derive-where/nightly"]
 safe = ["derive-where/safe"]
 zeroize = ["derive-where/zeroize"]
+zeroize-on-drop = ["derive-where/zeroize-on-drop", "zeroize"]
 
 [dependencies]
 derive-where = { path = ".." }
 
 [dev-dependencies]
 trybuild = { version = "1", default-features = false }
-zeroize_ = { version = "1", package = "zeroize", default-features = false }
+zeroize_ = { version = "1.5.0-pre", package = "zeroize", default-features = false }
 
 [lib]
 doctest = false

--- a/non-msrv-tests/tests/ui/zeroize/deprecated_drop.rs
+++ b/non-msrv-tests/tests/ui/zeroize/deprecated_drop.rs
@@ -1,0 +1,11 @@
+extern crate zeroize_ as zeroize;
+
+use std::marker::PhantomData;
+
+use derive_where::DeriveWhere;
+
+#[derive(DeriveWhere)]
+#[derive_where(Zeroize(drop))]
+struct DeprecatedDrop<T>(PhantomData<T>);
+
+fn main() {}

--- a/non-msrv-tests/tests/ui/zeroize/deprecated_drop.stderr
+++ b/non-msrv-tests/tests/ui/zeroize/deprecated_drop.stderr
@@ -1,0 +1,5 @@
+error: `Zeroize(drop)` is deprecated, use `ZeroizeOnDrop` instead
+ --> tests/ui/zeroize/deprecated_drop.rs:8:24
+  |
+8 | #[derive_where(Zeroize(drop))]
+  |                        ^^^^

--- a/non-msrv-tests/tests/ui/zeroize/item.stderr
+++ b/non-msrv-tests/tests/ui/zeroize/item.stderr
@@ -1,34 +1,34 @@
-error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize
+error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
  --> tests/ui/zeroize/item.rs:6:16
   |
 6 | #[derive_where(skip_inner, Clone)]
   |                ^^^^^^^^^^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize
+error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:10:24
    |
 10 | #[derive_where(Debug = invalid; T)]
    |                        ^^^^^^^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize
+error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:14:16
    |
 14 | #[derive_where(,)]
    |                ^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize
+error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:18:16
    |
 18 | #[derive_where(,Clone)]
    |                ^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize
+error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:22:22
    |
 22 | #[derive_where(Clone,,)]
    |                      ^
 
-error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize
+error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:26:16
    |
 26 | #[derive_where(T)]

--- a/non-msrv-tests/tests/ui/zeroize/zeroize.rs
+++ b/non-msrv-tests/tests/ui/zeroize/zeroize.rs
@@ -25,27 +25,7 @@ struct WrongCrateSyntax<T>(PhantomData<T>);
 struct InvalidCrate<T>(PhantomData<T>);
 
 #[derive(DeriveWhere)]
-#[derive_where(Zeroize(drop, drop))]
-struct DuplicateDrop<T>(PhantomData<T>);
-
-#[derive(DeriveWhere)]
 #[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_"))]
 struct DuplicateCrate<T>(PhantomData<T>);
-
-#[derive(DeriveWhere)]
-#[derive_where(Zeroize(drop, drop, crate = "zeroize_"))]
-struct DuplicateDropWithCrate<T>(PhantomData<T>);
-
-#[derive(DeriveWhere)]
-#[derive_where(Zeroize(drop, crate = "zeroize_", crate = "zeroize_"))]
-struct DropWithDuplicateCrate<T>(PhantomData<T>);
-
-#[derive(DeriveWhere)]
-#[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_", drop))]
-struct DuplicateCrateWithDrop<T>(PhantomData<T>);
-
-#[derive(DeriveWhere)]
-#[derive_where(Zeroize(crate = "zeroize_", drop, drop))]
-struct CrateWithDuplicateDrop<T>(PhantomData<T>);
 
 fn main() {}

--- a/non-msrv-tests/tests/ui/zeroize/zeroize.stderr
+++ b/non-msrv-tests/tests/ui/zeroize/zeroize.stderr
@@ -28,38 +28,8 @@ error: expected path, expected identifier
 24 | #[derive_where(Zeroize(crate = "struct Test"))]
    |                                ^^^^^^^^^^^^^
 
-error: duplicate `drop` option
-  --> tests/ui/zeroize/zeroize.rs:28:30
-   |
-28 | #[derive_where(Zeroize(drop, drop))]
-   |                              ^^^^
-
 error: duplicate `crate` option
-  --> tests/ui/zeroize/zeroize.rs:32:44
+  --> tests/ui/zeroize/zeroize.rs:28:44
    |
-32 | #[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_"))]
+28 | #[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_"))]
    |                                            ^^^^^^^^^^^^^^^^^^
-
-error: duplicate `drop` option
-  --> tests/ui/zeroize/zeroize.rs:36:30
-   |
-36 | #[derive_where(Zeroize(drop, drop, crate = "zeroize_"))]
-   |                              ^^^^
-
-error: duplicate `crate` option
-  --> tests/ui/zeroize/zeroize.rs:40:50
-   |
-40 | #[derive_where(Zeroize(drop, crate = "zeroize_", crate = "zeroize_"))]
-   |                                                  ^^^^^^^^^^^^^^^^^^
-
-error: duplicate `crate` option
-  --> tests/ui/zeroize/zeroize.rs:44:44
-   |
-44 | #[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_", drop))]
-   |                                            ^^^^^^^^^^^^^^^^^^
-
-error: duplicate `drop` option
-  --> tests/ui/zeroize/zeroize.rs:48:50
-   |
-48 | #[derive_where(Zeroize(crate = "zeroize_", drop, drop))]
-   |                                                  ^^^^

--- a/non-msrv-tests/tests/util.rs
+++ b/non-msrv-tests/tests/util.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 #[cfg(feature = "zeroize")]
-use zeroize_::{Zeroize, ZeroizeOnDrop};
+use zeroize_::Zeroize;
+#[cfg(feature = "zeroize-on-drop")]
+use zeroize_::ZeroizeOnDrop;
 
 pub struct Wrapper<T = ()> {
 	data: i32,
@@ -44,7 +46,7 @@ impl<T> Zeroize for Wrapper<T> {
 #[cfg(feature = "zeroize")]
 pub struct AssertZeroize<'a, T: Zeroize>(pub &'a T);
 
-#[cfg(feature = "zeroize")]
+#[cfg(feature = "zeroize-on-drop")]
 pub struct AssertZeroizeOnDrop<'a, T: ZeroizeOnDrop>(pub &'a T);
 
 pub fn test_drop<T>(value: T, fun: impl FnOnce(&T)) {

--- a/non-msrv-tests/tests/util.rs
+++ b/non-msrv-tests/tests/util.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[cfg(feature = "zeroize")]
-use zeroize_::Zeroize;
+use zeroize_::{Zeroize, ZeroizeOnDrop};
 
 pub struct Wrapper<T = ()> {
 	data: i32,
@@ -43,6 +43,9 @@ impl<T> Zeroize for Wrapper<T> {
 
 #[cfg(feature = "zeroize")]
 pub struct AssertZeroize<'a, T: Zeroize>(pub &'a T);
+
+#[cfg(feature = "zeroize")]
+pub struct AssertZeroizeOnDrop<'a, T: ZeroizeOnDrop>(pub &'a T);
 
 pub fn test_drop<T>(value: T, fun: impl FnOnce(&T)) {
 	let mut test_holder = vec![value];

--- a/non-msrv-tests/tests/zeroize.rs
+++ b/non-msrv-tests/tests/zeroize.rs
@@ -6,13 +6,16 @@ mod util;
 
 use std::{
 	marker::PhantomData,
+	mem,
 	ops::{Deref, DerefMut},
 };
 
 use derive_where::DeriveWhere;
 use zeroize::Zeroize;
 
-use self::util::{AssertZeroize, AssertZeroizeOnDrop, Wrapper};
+#[cfg(feature = "zeroize-on-drop")]
+use self::util::AssertZeroizeOnDrop;
+use self::util::{AssertZeroize, Wrapper};
 
 #[test]
 fn basic() {
@@ -57,7 +60,9 @@ fn drop() {
 	let mut test = Test(42.into());
 
 	let _ = AssertZeroize(&test);
+	#[cfg(feature = "zeroize-on-drop")]
 	let _ = AssertZeroizeOnDrop(&test);
+	assert!(mem::needs_drop::<Test<()>>());
 
 	test.zeroize();
 
@@ -90,7 +95,9 @@ fn fqs() {
 	let mut test = Test(Fqs(42.into()));
 
 	let _ = AssertZeroize(&test);
+	#[cfg(feature = "zeroize-on-drop")]
 	let _ = AssertZeroizeOnDrop(&test);
+	assert!(mem::needs_drop::<Test<()>>());
 
 	test.zeroize();
 
@@ -124,7 +131,9 @@ fn deref() {
 	let mut test = Test::<()>(ZeroizeDeref(42, PhantomData));
 
 	let _ = AssertZeroize(&test);
+	#[cfg(feature = "zeroize-on-drop")]
 	let _ = AssertZeroizeOnDrop(&test);
+	assert!(mem::needs_drop::<Test<()>>());
 
 	test.zeroize();
 

--- a/non-msrv-tests/tests/zeroize.rs
+++ b/non-msrv-tests/tests/zeroize.rs
@@ -12,7 +12,7 @@ use std::{
 use derive_where::DeriveWhere;
 use zeroize::Zeroize;
 
-use self::util::{AssertZeroize, Wrapper};
+use self::util::{AssertZeroize, AssertZeroizeOnDrop, Wrapper};
 
 #[test]
 fn basic() {
@@ -51,12 +51,13 @@ fn crate_() {
 #[test]
 fn drop() {
 	#[derive(DeriveWhere)]
-	#[derive_where(Zeroize(drop))]
+	#[derive_where(Zeroize, ZeroizeOnDrop)]
 	struct Test<T>(Wrapper<T>);
 
 	let mut test = Test(42.into());
 
 	let _ = AssertZeroize(&test);
+	let _ = AssertZeroizeOnDrop(&test);
 
 	test.zeroize();
 
@@ -83,12 +84,13 @@ fn fqs() {
 	}
 
 	#[derive(DeriveWhere)]
-	#[derive_where(Zeroize(drop))]
+	#[derive_where(Zeroize, ZeroizeOnDrop)]
 	struct Test<T>(#[derive_where(Zeroize(fqs))] Fqs<T>);
 
 	let mut test = Test(Fqs(42.into()));
 
 	let _ = AssertZeroize(&test);
+	let _ = AssertZeroizeOnDrop(&test);
 
 	test.zeroize();
 
@@ -116,12 +118,13 @@ fn deref() {
 	}
 
 	#[derive(DeriveWhere)]
-	#[derive_where(Zeroize(drop))]
+	#[derive_where(Zeroize, ZeroizeOnDrop)]
 	struct Test<T>(ZeroizeDeref<T>);
 
 	let mut test = Test::<()>(ZeroizeDeref(42, PhantomData));
 
 	let _ = AssertZeroize(&test);
+	let _ = AssertZeroizeOnDrop(&test);
 
 	test.zeroize();
 

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -408,33 +408,50 @@ impl DeriveTrait {
 		use DeriveTrait::*;
 
 		match self {
-			Clone => util::path_from_strs(&["core", "clone", "Clone"]),
-			Copy => util::path_from_strs(&["core", "marker", "Copy"]),
-			Debug => util::path_from_strs(&["core", "fmt", "Debug"]),
-			Default => util::path_from_strs(&["core", "default", "Default"]),
-			Eq => util::path_from_strs(&["core", "cmp", "Eq"]),
-			Hash => util::path_from_strs(&["core", "hash", "Hash"]),
-			Ord => util::path_from_strs(&["core", "cmp", "Ord"]),
-			PartialEq => util::path_from_strs(&["core", "cmp", "PartialEq"]),
-			PartialOrd => util::path_from_strs(&["core", "cmp", "PartialOrd"]),
+			Clone => util::path_from_root_and_strs(self.crate_(), &["clone", "Clone"]),
+			Copy => util::path_from_root_and_strs(self.crate_(), &["marker", "Copy"]),
+			Debug => util::path_from_root_and_strs(self.crate_(), &["fmt", "Debug"]),
+			Default => util::path_from_root_and_strs(self.crate_(), &["default", "Default"]),
+			Eq => util::path_from_root_and_strs(self.crate_(), &["cmp", "Eq"]),
+			Hash => util::path_from_root_and_strs(self.crate_(), &["hash", "Hash"]),
+			Ord => util::path_from_root_and_strs(self.crate_(), &["cmp", "Ord"]),
+			PartialEq => util::path_from_root_and_strs(self.crate_(), &["cmp", "PartialEq"]),
+			PartialOrd => util::path_from_root_and_strs(self.crate_(), &["cmp", "PartialOrd"]),
+			#[cfg(feature = "zeroize")]
+			Zeroize { .. } => util::path_from_root_and_strs(self.crate_(), &["Zeroize"]),
+			#[cfg(feature = "zeroize")]
+			ZeroizeOnDrop { .. } => util::path_from_root_and_strs(self.crate_(), &["ZeroizeOnDrop"]),
+		}
+	}
+
+	/// Returns the path to the root crate for this trait.
+	pub fn crate_(&self) -> Path {
+		use DeriveTrait::*;
+
+		match self {
+			Clone => util::path_from_strs(&["core"]),
+			Copy => util::path_from_strs(&["core"]),
+			Debug => util::path_from_strs(&["core"]),
+			Default => util::path_from_strs(&["core"]),
+			Eq => util::path_from_strs(&["core"]),
+			Hash => util::path_from_strs(&["core"]),
+			Ord => util::path_from_strs(&["core"]),
+			PartialEq => util::path_from_strs(&["core"]),
+			PartialOrd => util::path_from_strs(&["core"]),
 			#[cfg(feature = "zeroize")]
 			Zeroize { crate_, .. } => {
 				if let Some(crate_) = crate_ {
-					let mut crate_ = crate_.clone();
-					crate_.segments.push(util::path_segment("Zeroize"));
-					crate_
+					crate_.clone()
 				} else {
-					util::path_from_strs(&["zeroize", "Zeroize"])
+					util::path_from_strs(&["zeroize"])
 				}
 			}
 			#[cfg(feature = "zeroize")]
 			ZeroizeOnDrop { crate_, .. } => {
 				if let Some(crate_) = crate_ {
-					let mut crate_ = crate_.clone();
-					crate_.segments.push(util::path_segment("ZeroizeOnDrop"));
-					crate_
+					crate_.clone()
 				} else {
-					util::path_from_strs(&["zeroize", "ZeroizeOnDrop"])
+					util::path_from_strs(&["zeroize"])
 				}
 			}
 		}

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -309,8 +309,12 @@ pub enum DeriveTrait {
 	Zeroize {
 		/// [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) path.
 		crate_: Option<Path>,
-		/// [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) [`Drop`] implementation.
-		drop: bool,
+	},
+	/// [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html).
+	#[cfg(feature = "zeroize")]
+	ZeroizeOnDrop {
+		/// [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html) path.
+		crate_: Option<Path>,
 	},
 }
 
@@ -340,6 +344,8 @@ impl Deref for DeriveTrait {
 			PartialOrd => &Trait::PartialOrd,
 			#[cfg(feature = "zeroize")]
 			Zeroize { .. } => &Trait::Zeroize,
+			#[cfg(feature = "zeroize")]
+			ZeroizeOnDrop { .. } => &Trait::ZeroizeOnDrop,
 		}
 	}
 }
@@ -419,6 +425,16 @@ impl DeriveTrait {
 					crate_
 				} else {
 					util::path_from_strs(&["zeroize", "Zeroize"])
+				}
+			}
+			#[cfg(feature = "zeroize")]
+			ZeroizeOnDrop { crate_, .. } => {
+				if let Some(crate_) = crate_ {
+					let mut crate_ = crate_.clone();
+					crate_.segments.push(util::path_segment("ZeroizeOnDrop"));
+					crate_
+				} else {
+					util::path_from_strs(&["zeroize", "ZeroizeOnDrop"])
 				}
 			}
 		}

--- a/src/error.rs
+++ b/src/error.rs
@@ -239,4 +239,13 @@ impl Error {
 			"`Zeroize` option is only supported if `Zeroize` is being implemented",
 		)
 	}
+
+	/// Deprecated use of `Zeroize(drop)`.
+	#[cfg(feature = "zeroize")]
+	pub fn deprecated_zeroize_drop(span: Span) -> syn::Error {
+		syn::Error::new(
+			span,
+			"`Zeroize(drop)` is deprecated, use `ZeroizeOnDrop` instead",
+		)
+	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -225,6 +225,8 @@ impl Error {
 			"PartialOrd",
 			#[cfg(feature = "zeroize")]
 			"Zeroize",
+			#[cfg(feature = "zeroize")]
+			"ZeroizeOnDrop",
 		]
 		.join(", ")
 	}

--- a/src/input.rs
+++ b/src/input.rs
@@ -144,10 +144,11 @@ impl<'a> Input<'a> {
 				#[cfg(feature = "zeroize")]
 				{
 					// `Zeroize(crate = "..")` is used.
-					if let DeriveTrait::Zeroize {
-						crate_: Some(_), ..
-					} = **trait_
-					{
+					if let DeriveTrait::Zeroize { crate_: Some(_) } = **trait_ {
+						continue;
+					}
+					// `ZeroizeOnDrop(crate = "..")` is used.
+					if let DeriveTrait::ZeroizeOnDrop { crate_: Some(_) } = **trait_ {
 						continue;
 					}
 					// `Zeroize(fqs)` is used on any field.

--- a/src/input.rs
+++ b/src/input.rs
@@ -137,20 +137,21 @@ impl<'a> Input<'a> {
 				if trait_ == Trait::Default && item.is_enum() {
 					continue;
 				}
+
 				// Any field is skipped with a corresponding `Trait`.
 				if item.any_skip_trait(trait_) {
 					continue;
 				}
+
 				#[cfg(feature = "zeroize")]
 				{
-					// `Zeroize(crate = "..")` is used.
-					if let DeriveTrait::Zeroize { crate_: Some(_) } = **trait_ {
+					// `Zeroize(crate = "..")` or `ZeroizeOnDrop(crate = "..")` is used.
+					if let DeriveTrait::Zeroize { crate_: Some(_) }
+					| DeriveTrait::ZeroizeOnDrop { crate_: Some(_) } = **trait_
+					{
 						continue;
 					}
-					// `ZeroizeOnDrop(crate = "..")` is used.
-					if let DeriveTrait::ZeroizeOnDrop { crate_: Some(_) } = **trait_ {
-						continue;
-					}
+
 					// `Zeroize(fqs)` is used on any field.
 					if trait_ == Trait::Zeroize && item.any_fqs() {
 						continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,12 +217,16 @@
 //!
 //! ## `ZeroizeOnDrop` options
 //!
+//! If the `zeroize-on-drop` feature is enabled, it implements [`ZeroizeOnDrop`]
+//! and can be implemented without [`Zeroize`], otherwise it only implements
+//! [`Drop`] and requires [`Zeroize`] to be implemented.
+//!
 //! [`ZeroizeOnDrop`] has one option:
 //! - `crate`: an item-level option which specifies a path to the `zeroize`
 //!   crate in case of a re-export or rename.
 //!
 //! ```
-//! # #[cfg(feature = "zeroize")]
+//! # #[cfg(feature = "zeroize-on-drop")]
 //! # {
 //! # use std::marker::PhantomData;
 //! # use derive_where::DeriveWhere;
@@ -266,7 +270,9 @@
 //! - [`PartialEq`]
 //! - [`PartialOrd`]
 //! - [`Zeroize`]: Only available with the `zeroize` crate feature.
-//! - [`ZeroizeOnDrop`]: Only available with the `zeroize` crate feature.
+//! - [`ZeroizeOnDrop`]: Only available with the `zeroize` crate feature. If the
+//!   `zeroize-on-drop` feature is enabled, it implements [`ZeroizeOnDrop`],
+//!   otherwise it only implements [`Drop`].
 //!
 //! ## Supported items
 //!
@@ -293,7 +299,9 @@
 //!   replaces all cases of [`core::hint::unreachable_unchecked`] in [`Ord`],
 //!   [`PartialEq`] and [`PartialOrd`], which is what std uses, with
 //!   [`unreachable`].
-//! - `zeroize`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`].
+//! - `zeroize`: Allows deriving [`Zeroize`] and [`method@zeroize`] on [`Drop`].
+//! - `zeroize-on-drop`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`] and
+//!   requires [zeroize] v1.5.0-pre.
 //!
 //! # MSRV
 //!
@@ -331,11 +339,12 @@
 //! [CHANGELOG]: https://github.com/ModProg/derive-where/blob/main/CHANGELOG.md
 //! [LICENSE-MIT]: https://github.com/ModProg/derive-where/blob/main/LICENSE-MIT
 //! [LICENSE-APACHE]: https://github.com/ModProg/derive-where/blob/main/LICENSE-APACHE
+//! [zeroize]: https://crates.io/crates/zeroize/1.5.0-pre
 //! [`Debug`]: core::fmt::Debug
 //! [`Default`]: core::default::Default
 //! [`Hash`]: core::hash::Hash
 //! [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
-//! [`ZeroizeOnDrop`]: https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html
+//! [`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5.0-pre/zeroize/trait.ZeroizeOnDrop.html
 //! [`method@zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
 //! [#27]: https://github.com/ModProg/derive-where/issues/27
 

--- a/src/test/zeroize.rs
+++ b/src/test/zeroize.rs
@@ -31,7 +31,38 @@ fn basic() -> Result<()> {
 fn drop() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Zeroize(drop); T)]
+			#[derive_where(ZeroizeOnDrop; T)]
+			struct Test<T, U>(T, std::marker::PhantomData<U>);
+		},
+		quote! {
+			impl<T, U> ::core::ops::Drop for Test<T, U>
+			where T: ::zeroize::ZeroizeOnDrop
+			{
+				fn drop(&mut self) {
+					use ::zeroize::__internal::AssertZeroize;
+					use ::zeroize::__internal::AssertZeroizeOnDrop;
+
+					match self {
+						Test(ref mut __0, ref mut __1) => {
+							__0.zeroize_or_on_drop();
+							__1.zeroize_or_on_drop();
+						}
+					}
+				}
+			}
+
+			impl<T, U> ::zeroize::ZeroizeOnDrop for Test<T, U>
+			where T: ::zeroize::ZeroizeOnDrop
+			{ }
+		},
+	)
+}
+
+#[test]
+fn both() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Zeroize, ZeroizeOnDrop; T)]
 			struct Test<T, U>(T, std::marker::PhantomData<U>);
 		},
 		quote! {
@@ -51,12 +82,24 @@ fn drop() -> Result<()> {
 			}
 
 			impl<T, U> ::core::ops::Drop for Test<T, U>
-			where T: ::zeroize::Zeroize
+			where T: ::zeroize::ZeroizeOnDrop
 			{
 				fn drop(&mut self) {
-					::zeroize::Zeroize::zeroize(self);
+					use ::zeroize::__internal::AssertZeroize;
+					use ::zeroize::__internal::AssertZeroizeOnDrop;
+
+					match self {
+						Test(ref mut __0, ref mut __1) => {
+							__0.zeroize_or_on_drop();
+							__1.zeroize_or_on_drop();
+						}
+					}
 				}
 			}
+
+			impl<T, U> ::zeroize::ZeroizeOnDrop for Test<T, U>
+			where T: ::zeroize::ZeroizeOnDrop
+			{ }
 		},
 	)
 }
@@ -90,31 +133,28 @@ fn crate_() -> Result<()> {
 fn drop_crate() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Zeroize(drop, crate = "zeroize_"); T)]
+			#[derive_where(ZeroizeOnDrop(crate = "zeroize_"); T)]
 			struct Test<T>(T);
 		},
 		quote! {
-			impl<T> zeroize_::Zeroize for Test<T>
-			where T: zeroize_::Zeroize
+			impl<T> ::core::ops::Drop for Test<T>
+			where T: zeroize_::ZeroizeOnDrop
 			{
-				fn zeroize(&mut self) {
-					use zeroize_::Zeroize;
+				fn drop(&mut self) {
+					use zeroize_::__internal::AssertZeroize;
+					use zeroize_::__internal::AssertZeroizeOnDrop;
 
 					match self {
 						Test(ref mut __0) => {
-							__0.zeroize();
+							__0.zeroize_or_on_drop();
 						}
 					}
 				}
 			}
 
-			impl<T> ::core::ops::Drop for Test<T>
-			where T: zeroize_::Zeroize
-			{
-				fn drop(&mut self) {
-					zeroize_::Zeroize::zeroize(self);
-				}
-			}
+			impl<T> zeroize_::ZeroizeOnDrop for Test<T>
+			where T: zeroize_::ZeroizeOnDrop
+			{ }
 		},
 	)
 }
@@ -123,31 +163,28 @@ fn drop_crate() -> Result<()> {
 fn crate_drop() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Zeroize(crate = "zeroize_", drop); T)]
+			#[derive_where(ZeroizeOnDrop(crate = "zeroize_"); T)]
 			struct Test<T>(T);
 		},
 		quote! {
-			impl<T> zeroize_::Zeroize for Test<T>
-			where T: zeroize_::Zeroize
+			impl<T> ::core::ops::Drop for Test<T>
+			where T: zeroize_::ZeroizeOnDrop
 			{
-				fn zeroize(&mut self) {
-					use zeroize_::Zeroize;
+				fn drop(&mut self) {
+					use zeroize_::__internal::AssertZeroize;
+					use zeroize_::__internal::AssertZeroizeOnDrop;
 
 					match self {
 						Test(ref mut __0) => {
-							__0.zeroize();
+							__0.zeroize_or_on_drop();
 						}
 					}
 				}
 			}
 
-			impl<T> ::core::ops::Drop for Test<T>
-			where T: zeroize_::Zeroize
-			{
-				fn drop(&mut self) {
-					zeroize_::Zeroize::zeroize(self);
-				}
-			}
+			impl<T> zeroize_::ZeroizeOnDrop for Test<T>
+			where T: zeroize_::ZeroizeOnDrop
+			{ }
 		},
 	)
 }

--- a/src/trait_/zeroize.rs
+++ b/src/trait_/zeroize.rs
@@ -27,7 +27,11 @@ impl TraitImpl for Zeroize {
 		for nested_meta in list.nested {
 			match &nested_meta {
 				NestedMeta::Meta(Meta::Path(path)) => {
-					return Err(Error::option_trait(path.span(), self.as_str()))
+					if path.is_ident("drop") {
+						return Err(Error::deprecated_zeroize_drop(path.span()));
+					} else {
+						return Err(Error::option_trait(path.span(), self.as_str()));
+					}
 				}
 				NestedMeta::Meta(Meta::NameValue(name_value)) => {
 					if name_value.path.is_ident("crate") {

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,7 @@ pub fn path_segment(ident: &str) -> PathSegment {
 	}
 }
 
-/// Create [`Path`] from `[&str]`.
+/// Create [`Path`] from `[&str]`s.
 pub fn path_from_strs(segments: &[&str]) -> Path {
 	Path {
 		leading_colon: Some(<Token![::]>::default()),
@@ -37,5 +37,17 @@ pub fn path_from_idents(segments: &[&Ident]) -> Path {
 			ident: (*ident).clone(),
 			arguments: PathArguments::None,
 		})),
+	}
+}
+
+/// Create [`Path`] from a root [`Path`] and `[&str]`s.
+pub fn path_from_root_and_strs(root: Path, segments: &[&str]) -> Path {
+	Path {
+		leading_colon: root.leading_colon,
+		segments: root
+			.segments
+			.into_iter()
+			.chain(segments.iter().map(|segment| path_segment(segment)))
+			.collect(),
 	}
 }


### PR DESCRIPTION
This is waiting for RustCrypto/utils#700 and a new release. Deprecates `Zeroize(drop)` in favor of `ZeroizeOnDrop`.