### PR TITLE
Attribute proc-macro follow up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support [`ZeroizeOnDrop`](https://docs.rs/zeroize/1.5.0/zeroize/trait.ZeroizeOnDrop.html).
 
+### Changed
+- **Breaking Change**: Changed to attribute instead of derive proc macro.
+
 ### Removed
 - **Breaking Change**: Remove support for `Zeroize(drop)`.
 

--- a/README.md
+++ b/README.md
@@ -34,55 +34,12 @@ struct Example<T>(PhantomData<T>);
 ```
 
 Multiple `derive_where` attributes can be added to an item, but only the
-first one should use any path qualifications. Otherwise helper attributes
-won't be applied to any but the first `derive_where` attribute on the item.
+first one must use any path qualifications.
 
 ```rust
-#[derive_where::derive_where(Clone, Debug; T)]
-#[derive_where(PartialEq)]
-struct Example1<T, U> {
-	a: u8,
-	#[derive_where(skip)]
-	b: u8,
-	ph: PhantomData<(T, U)>,
-}
-
-let var1 = Example1 {
-	a: 42,
-	b: 42,
-	ph: PhantomData::<((), ())>,
-};
-let var2 = Example1 {
-	a: 42,
-	b: 0,
-	ph: PhantomData::<((), ())>,
-};
-
-// Field `b` is not compared, as expected.
-assert_eq!(var1, var2);
-
-#[derive_where::derive_where(Clone, Debug; T)]
-#[derive_where::derive_where(PartialEq)]
-struct Example2<T, U> {
-	a: u8,
-	#[derive_where(skip)]
-	b: u8,
-	ph: PhantomData<(T, U)>,
-}
-
-let var1 = Example2 {
-	a: 42,
-	b: 42,
-	ph: PhantomData::<((), ())>,
-};
-let var2 = Example2 {
-	a: 42,
-	b: 0,
-	ph: PhantomData::<((), ())>,
-};
-
-// Field `b` is compared!
-assert_ne!(var1, var2);
+#[derive_where::derive_where(Clone)]
+#[derive_where(Debug)]
+struct Example1<T>(PhantomData<T>);
 ```
 
 In addition, the following convenience options are available:

--- a/README.md
+++ b/README.md
@@ -24,16 +24,6 @@ as opposed to std's derives, which would only implement these traits with
 `T: Trait` bound to the corresponding trait.
 
 Multiple `derive_where` attributes can be added to an item, but only the
-first one should use any path qualifications. Otherwise helper attributes
-won't be applied to any but the first `derive_where` attribute on the item.
-
-```rust
-#[derive_where::derive_where(Clone, Debug)]
-#[derive_where(Default, Hash)]
-struct Example<T>(PhantomData<T>);
-```
-
-Multiple `derive_where` attributes can be added to an item, but only the
 first one must use any path qualifications.
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -23,6 +23,68 @@ This will generate trait implementations for `Example` for any `T`,
 as opposed to std's derives, which would only implement these traits with
 `T: Trait` bound to the corresponding trait.
 
+Multiple `derive_where` attributes can be added to an item, but only the
+first one should use any path qualifications. Otherwise helper attributes
+won't be applied to any but the first `derive_where` attribute on the item.
+
+```rust
+#[derive_where::derive_where(Clone, Debug)]
+#[derive_where(Default, Hash)]
+struct Example<T>(PhantomData<T>);
+```
+
+Multiple `derive_where` attributes can be added to an item, but only the
+first one should use any path qualifications. Otherwise helper attributes
+won't be applied to any but the first `derive_where` attribute on the item.
+
+```rust
+#[derive_where::derive_where(Clone, Debug; T)]
+#[derive_where(PartialEq)]
+struct Example1<T, U> {
+	a: u8,
+	#[derive_where(skip)]
+	b: u8,
+	ph: PhantomData<(T, U)>,
+}
+
+let var1 = Example1 {
+	a: 42,
+	b: 42,
+	ph: PhantomData::<((), ())>,
+};
+let var2 = Example1 {
+	a: 42,
+	b: 0,
+	ph: PhantomData::<((), ())>,
+};
+
+// Field `b` is not compared, as expected.
+assert_eq!(var1, var2);
+
+#[derive_where::derive_where(Clone, Debug; T)]
+#[derive_where::derive_where(PartialEq)]
+struct Example2<T, U> {
+	a: u8,
+	#[derive_where(skip)]
+	b: u8,
+	ph: PhantomData<(T, U)>,
+}
+
+let var1 = Example2 {
+	a: 42,
+	b: 42,
+	ph: PhantomData::<((), ())>,
+};
+let var2 = Example2 {
+	a: 42,
+	b: 0,
+	ph: PhantomData::<((), ())>,
+};
+
+// Field `b` is compared!
+assert_ne!(var1, var2);
+```
+
 In addition, the following convenience options are available:
 
 ### Generic type bounds

--- a/non-msrv-tests/tests/ui/non_item.rs
+++ b/non-msrv-tests/tests/ui/non_item.rs
@@ -1,0 +1,6 @@
+use derive_where::derive_where;
+
+#[derive_where(Clone)]
+const _: () = ();
+
+fn main() {}

--- a/non-msrv-tests/tests/ui/non_item.stderr
+++ b/non-msrv-tests/tests/ui/non_item.stderr
@@ -1,0 +1,5 @@
+error: expected one of: `struct`, `enum`, `union`
+ --> tests/ui/non_item.rs:4:1
+  |
+4 | const _: () = ();
+  | ^^^^^

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,59 @@
 //! as opposed to std's derives, which would only implement these traits with
 //! `T: Trait` bound to the corresponding trait.
 //!
+//! Multiple `derive_where` attributes can be added to an item, but only the
+//! first one should use any path qualifications. Otherwise helper attributes
+//! won't be applied to any but the first `derive_where` attribute on the item.
+//!
+//! ```
+//! # use std::marker::PhantomData;
+//! #[derive_where::derive_where(Clone, Debug; T)]
+//! #[derive_where(PartialEq)]
+//! struct Example1<T, U> {
+//! 	a: u8,
+//! 	#[derive_where(skip)]
+//! 	b: u8,
+//! 	ph: PhantomData<(T, U)>,
+//! }
+//!
+//! let var1 = Example1 {
+//! 	a: 42,
+//! 	b: 42,
+//! 	ph: PhantomData::<((), ())>,
+//! };
+//! let var2 = Example1 {
+//! 	a: 42,
+//! 	b: 0,
+//! 	ph: PhantomData::<((), ())>,
+//! };
+//!
+//! // Field `b` is not compared, as expected.
+//! assert_eq!(var1, var2);
+//!
+//! #[derive_where::derive_where(Clone, Debug; T)]
+//! #[derive_where::derive_where(PartialEq)]
+//! struct Example2<T, U> {
+//! 	a: u8,
+//! 	#[derive_where(skip)]
+//! 	b: u8,
+//! 	ph: PhantomData<(T, U)>,
+//! }
+//!
+//! let var1 = Example2 {
+//! 	a: 42,
+//! 	b: 42,
+//! 	ph: PhantomData::<((), ())>,
+//! };
+//! let var2 = Example2 {
+//! 	a: 42,
+//! 	b: 0,
+//! 	ph: PhantomData::<((), ())>,
+//! };
+//!
+//! // Field `b` is compared!
+//! assert_ne!(var1, var2);
+//! ```
+//!
 //! In addition, the following convenience options are available:
 //!
 //! ## Generic type bounds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,56 +26,13 @@
 //! `T: Trait` bound to the corresponding trait.
 //!
 //! Multiple `derive_where` attributes can be added to an item, but only the
-//! first one should use any path qualifications. Otherwise helper attributes
-//! won't be applied to any but the first `derive_where` attribute on the item.
+//! first one must use any path qualifications.
 //!
 //! ```
 //! # use std::marker::PhantomData;
-//! #[derive_where::derive_where(Clone, Debug; T)]
-//! #[derive_where(PartialEq)]
-//! struct Example1<T, U> {
-//! 	a: u8,
-//! 	#[derive_where(skip)]
-//! 	b: u8,
-//! 	ph: PhantomData<(T, U)>,
-//! }
-//!
-//! let var1 = Example1 {
-//! 	a: 42,
-//! 	b: 42,
-//! 	ph: PhantomData::<((), ())>,
-//! };
-//! let var2 = Example1 {
-//! 	a: 42,
-//! 	b: 0,
-//! 	ph: PhantomData::<((), ())>,
-//! };
-//!
-//! // Field `b` is not compared, as expected.
-//! assert_eq!(var1, var2);
-//!
-//! #[derive_where::derive_where(Clone, Debug; T)]
-//! #[derive_where::derive_where(PartialEq)]
-//! struct Example2<T, U> {
-//! 	a: u8,
-//! 	#[derive_where(skip)]
-//! 	b: u8,
-//! 	ph: PhantomData<(T, U)>,
-//! }
-//!
-//! let var1 = Example2 {
-//! 	a: 42,
-//! 	b: 42,
-//! 	ph: PhantomData::<((), ())>,
-//! };
-//! let var2 = Example2 {
-//! 	a: 42,
-//! 	b: 0,
-//! 	ph: PhantomData::<((), ())>,
-//! };
-//!
-//! // Field `b` is compared!
-//! assert_ne!(var1, var2);
+//! #[derive_where::derive_where(Clone)]
+//! #[derive_where(Debug)]
+//! struct Example1<T>(PhantomData<T>);
 //! ```
 //!
 //! In addition, the following convenience options are available:


### PR DESCRIPTION
Fixes #35.

I added a note in the README, but noticed that actually setting the path can produce some pretty unexpected behavior.

What do you think of adding an error if a `derive_where::derive_where` is found as not the first attribute? This isn't bulletproof of course because `derive_where_export::derive_where` could still remain undetected.