### PR TITLE
Implement placeholder attribute to prevent multiple `derive_where`s with different paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support [`ZeroizeOnDrop`](https://docs.rs/zeroize/1.5.0-pre/zeroize/trait.ZeroizeOnDrop.html).
+- Support [`ZeroizeOnDrop`](https://docs.rs/zeroize/1.5.0/zeroize/trait.ZeroizeOnDrop.html).
 
 ### Removed
 - **Breaking Change**: Remove support for `Zeroize(drop)`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,11 @@ quote = { version = "1", default-features = false }
 syn = { version = "1", default-features = false, features = [
 	"clone-impls",
 	"derive",
+	"extra-traits",
 	"full",
 	"parsing",
 	"printing",
 ] }
-
-[dev-dependencies]
-syn = { version = "1", default-features = false, features = ["extra-traits"] }
 
 [[test]]
 name = "util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 default-members = [""]
-members = ["", "ensure-no-std", "non-msrv-tests"]
+members = ["", "crate_", "ensure-no-std", "non-msrv-tests"]
 resolver = "2"
 
 [package]

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Unions only support [`Clone`](https://doc.rust-lang.org/core/clone/trait.Clone.h
   [`unreachable`](https://doc.rust-lang.org/core/macro.unreachable.html).
 - `zeroize`: Allows deriving [`Zeroize`] and [`method@zeroize`] on [`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html).
 - `zeroize-on-drop`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`] and
-  requires [zeroize] v1.5.0-pre.
+  requires [zeroize] v1.5.0.
 
 ## MSRV
 
@@ -266,11 +266,11 @@ conditions.
 [CHANGELOG]: https://github.com/ModProg/derive-where/blob/main/CHANGELOG.md
 [LICENSE-MIT]: https://github.com/ModProg/derive-where/blob/main/LICENSE-MIT
 [LICENSE-APACHE]: https://github.com/ModProg/derive-where/blob/main/LICENSE-APACHE
-[zeroize]: https://crates.io/crates/zeroize/1.5.0-pre
+[zeroize]: https://crates.io/crates/zeroize/1.5.0
 [`Debug`]: https://doc.rust-lang.org/core/fmt/trait.Debug.html
 [`Default`]: https://doc.rust-lang.org/core/default/trait.Default.html
 [`Hash`]: https://doc.rust-lang.org/core/hash/trait.Hash.html
 [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
-[`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5.0-pre/zeroize/trait.ZeroizeOnDrop.html
+[`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5.0/zeroize/trait.ZeroizeOnDrop.html
 [`method@zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
 [#27]: https://github.com/ModProg/derive-where/issues/27

--- a/crate_/Cargo.toml
+++ b/crate_/Cargo.toml
@@ -12,7 +12,7 @@ zeroize-on-drop = ["derive-where_/zeroize-on-drop", "zeroize"]
 
 [dependencies]
 derive-where_ = { path = "..", package = "derive-where" }
-zeroize_ = { version = "1.5.0-pre", package = "zeroize", default-features = false, optional = true }
+zeroize_ = { version = "1.5.0", package = "zeroize", default-features = false, optional = true }
 
 [lib]
 doctest = false

--- a/crate_/Cargo.toml
+++ b/crate_/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+edition = "2018"
+name = "crate_"
+publish = false
+version = "0.0.0"
+
+[features]
+nightly = ["derive-where_/nightly"]
+safe = ["derive-where_/safe"]
+zeroize = ["derive-where_/zeroize", "zeroize_"]
+zeroize-on-drop = ["derive-where_/zeroize-on-drop", "zeroize"]
+
+[dependencies]
+derive-where_ = { path = "..", package = "derive-where" }
+zeroize_ = { version = "1.5.0-pre", package = "zeroize", default-features = false, optional = true }
+
+[lib]
+doctest = false
+test = false

--- a/crate_/src/lib.rs
+++ b/crate_/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+#[cfg(feature = "zeroize")]
+extern crate zeroize_ as zeroize;
+
+use core::marker::PhantomData;
+
+use derive_where_::derive_where;
+
+#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "zeroize", derive_where(Zeroize))]
+#[derive_where(crate = "derive_where_")]
+pub struct Test<T>(PhantomData<T>);

--- a/ensure-no-std/Cargo.toml
+++ b/ensure-no-std/Cargo.toml
@@ -12,7 +12,7 @@ zeroize-on-drop = ["derive-where/zeroize-on-drop", "zeroize"]
 
 [dependencies]
 derive-where = { path = ".." }
-zeroize_ = { version = "1.5.0-pre", package = "zeroize", default-features = false, optional = true }
+zeroize_ = { version = "1.5.0", package = "zeroize", default-features = false, optional = true }
 
 [lib]
 doctest = false

--- a/non-msrv-tests/Cargo.toml
+++ b/non-msrv-tests/Cargo.toml
@@ -15,7 +15,7 @@ derive-where = { path = ".." }
 
 [dev-dependencies]
 trybuild = { version = "1", default-features = false }
-zeroize_ = { version = "1.5.0-pre", package = "zeroize", default-features = false }
+zeroize_ = { version = "1.5.0", package = "zeroize", default-features = false }
 
 [lib]
 doctest = false

--- a/non-msrv-tests/tests/ui/item.rs
+++ b/non-msrv-tests/tests/ui/item.rs
@@ -8,6 +8,21 @@ struct NoOption<T>(PhantomData<T>);
 #[derive_where()]
 struct EmptyAttribute<T>(PhantomData<T>);
 
+#[derive_where(crate(derive_where_))]
+struct WrongCrateSyntax<T>(PhantomData<T>);
+
+#[derive_where(crate = "struct Test")]
+struct InvalidPath<T>(PhantomData<T>);
+
+#[derive_where(crate = "derive_where_", crate = "derive_where_")]
+struct DuplicateCrate1<T>(PhantomData<T>);
+
+#[derive_where(crate = "derive_where_")]
+struct OnlyCrate<T>(PhantomData<T>);
+
+#[derive_where(crate = "::derive_where")]
+struct DefaultCrate<T>(PhantomData<T>);
+
 #[derive_where(Clone; T;)]
 struct SemiColonAtTheEnd<T, U>(T, PhantomData<U>);
 

--- a/non-msrv-tests/tests/ui/item.rs
+++ b/non-msrv-tests/tests/ui/item.rs
@@ -41,4 +41,8 @@ struct MissingCommaBetweenGenerics<T, U, V>(T, PhantomData<(U, V)>);
 #[derive_where("Clone")]
 struct InvalidTrait<T>(PhantomData<T>);
 
+#[derive_where(Clone)]
+#[derive_where::derive_where(Copy)]
+struct QualifiedNotFirstMacro<T>(PhantomData<T>);
+
 fn main() {}

--- a/non-msrv-tests/tests/ui/item.rs
+++ b/non-msrv-tests/tests/ui/item.rs
@@ -14,8 +14,15 @@ struct WrongCrateSyntax<T>(PhantomData<T>);
 #[derive_where(crate = "struct Test")]
 struct InvalidPath<T>(PhantomData<T>);
 
+// The error message here shows that `crate = ".."` should be in it's own
+// attribute instead of an error pointing out this is duplicate. This is not
+// ideal but much less complicated to implement.
 #[derive_where(crate = "derive_where_", crate = "derive_where_")]
 struct DuplicateCrate1<T>(PhantomData<T>);
+
+#[derive_where(crate = "derive_where_")]
+#[derive_where(crate = "derive_where_")]
+struct DuplicateCrate2<T>(PhantomData<T>);
 
 #[derive_where(crate = "derive_where_")]
 struct OnlyCrate<T>(PhantomData<T>);

--- a/non-msrv-tests/tests/ui/item.stderr
+++ b/non-msrv-tests/tests/ui/item.stderr
@@ -27,63 +27,69 @@ error: expected path, expected identifier
    |                        ^^^^^^^^^^^^^
 
 error: the `crate` option has to be defined in it's own `#[derive_where(..)` attribute
-  --> tests/ui/item.rs:17:16
+  --> tests/ui/item.rs:20:16
    |
-17 | #[derive_where(crate = "derive_where_", crate = "derive_where_")]
+20 | #[derive_where(crate = "derive_where_", crate = "derive_where_")]
    |                ^^^^^
 
-error: no traits found to implement, use `#[derive_where(..)` to specify some
-  --> tests/ui/item.rs:21:1
+error: duplicate `crate` option
+  --> tests/ui/item.rs:24:16
    |
-21 | struct OnlyCrate<T>(PhantomData<T>);
+24 | #[derive_where(crate = "derive_where_")]
+   |                ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: no traits found to implement, use `#[derive_where(..)` to specify some
+  --> tests/ui/item.rs:28:1
+   |
+28 | struct OnlyCrate<T>(PhantomData<T>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unnecessary path qualification, `::derive_where` is used by default
-  --> tests/ui/item.rs:23:24
+  --> tests/ui/item.rs:30:24
    |
-23 | #[derive_where(crate = "::derive_where")]
+30 | #[derive_where(crate = "::derive_where")]
    |                        ^^^^^^^^^^^^^^^^
 
 error: expected `,`
-  --> tests/ui/item.rs:26:24
+  --> tests/ui/item.rs:33:24
    |
-26 | #[derive_where(Clone; T;)]
+33 | #[derive_where(Clone; T;)]
    |                        ^
 
 error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:29:25
+  --> tests/ui/item.rs:36:25
    |
-29 | #[derive_where(Clone; T,,)]
+36 | #[derive_where(Clone; T,,)]
    |                         ^
 
 error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:32:23
+  --> tests/ui/item.rs:39:23
    |
-32 | #[derive_where(Clone; where)]
+39 | #[derive_where(Clone; where)]
    |                       ^^^^^
 
 error: expected `;` or `,
-  --> tests/ui/item.rs:35:22
+  --> tests/ui/item.rs:42:22
    |
-35 | #[derive_where(Clone Debug)]
+42 | #[derive_where(Clone Debug)]
    |                      ^^^^^
 
 error: expected `,`
-  --> tests/ui/item.rs:38:25
+  --> tests/ui/item.rs:45:25
    |
-38 | #[derive_where(Clone; T U)]
+45 | #[derive_where(Clone; T U)]
    |                         ^
 
 error: unexpected option syntax
-  --> tests/ui/item.rs:41:16
+  --> tests/ui/item.rs:48:16
    |
-41 | #[derive_where("Clone")]
+48 | #[derive_where("Clone")]
    |                ^^^^^^^
 
 error: `#[derive_where(..)` was already applied to this item before, this occurs when using a qualified path for any `#[derive_where(..)`s except the first
-  --> tests/ui/item.rs:44:1
+  --> tests/ui/item.rs:51:1
    |
-44 | #[derive_where(Clone)]
+51 | #[derive_where(Clone)]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/non-msrv-tests/tests/ui/item.stderr
+++ b/non-msrv-tests/tests/ui/item.stderr
@@ -14,11 +14,11 @@ error: empty `derive_where` found
   |
   = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the `crate` option has to be defined in it's own `#[derive_where(..)` attribute
+error: unexpected option syntax
   --> tests/ui/item.rs:11:16
    |
 11 | #[derive_where(crate(derive_where_))]
-   |                ^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^
 
 error: expected path, expected identifier
   --> tests/ui/item.rs:14:24
@@ -79,3 +79,11 @@ error: unexpected option syntax
    |
 41 | #[derive_where("Clone")]
    |                ^^^^^^^
+
+error: `#[derive_where(..)` was already applied to this item before, this occurs when using a qualified path for any `#[derive_where(..)`s except the first
+  --> tests/ui/item.rs:44:1
+   |
+44 | #[derive_where(Clone)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/non-msrv-tests/tests/ui/item.stderr
+++ b/non-msrv-tests/tests/ui/item.stderr
@@ -14,38 +14,68 @@ error: empty `derive_where` found
   |
   = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: expected `,`
-  --> tests/ui/item.rs:11:24
+error: the `crate` option has to be defined in it's own `#[derive_where(..)` attribute
+  --> tests/ui/item.rs:11:16
    |
-11 | #[derive_where(Clone; T;)]
+11 | #[derive_where(crate(derive_where_))]
+   |                ^^^^^
+
+error: expected path, expected identifier
+  --> tests/ui/item.rs:14:24
+   |
+14 | #[derive_where(crate = "struct Test")]
+   |                        ^^^^^^^^^^^^^
+
+error: the `crate` option has to be defined in it's own `#[derive_where(..)` attribute
+  --> tests/ui/item.rs:17:16
+   |
+17 | #[derive_where(crate = "derive_where_", crate = "derive_where_")]
+   |                ^^^^^
+
+error: no traits found to implement, use `#[derive_where(..)` to specify some
+  --> tests/ui/item.rs:21:1
+   |
+21 | struct OnlyCrate<T>(PhantomData<T>);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unnecessary path qualification, `::derive_where` is used by default
+  --> tests/ui/item.rs:23:24
+   |
+23 | #[derive_where(crate = "::derive_where")]
+   |                        ^^^^^^^^^^^^^^^^
+
+error: expected `,`
+  --> tests/ui/item.rs:26:24
+   |
+26 | #[derive_where(Clone; T;)]
    |                        ^
 
 error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:14:25
+  --> tests/ui/item.rs:29:25
    |
-14 | #[derive_where(Clone; T,,)]
+29 | #[derive_where(Clone; T,,)]
    |                         ^
 
 error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:17:23
+  --> tests/ui/item.rs:32:23
    |
-17 | #[derive_where(Clone; where)]
+32 | #[derive_where(Clone; where)]
    |                       ^^^^^
 
 error: expected `;` or `,
-  --> tests/ui/item.rs:20:22
+  --> tests/ui/item.rs:35:22
    |
-20 | #[derive_where(Clone Debug)]
+35 | #[derive_where(Clone Debug)]
    |                      ^^^^^
 
 error: expected `,`
-  --> tests/ui/item.rs:23:25
+  --> tests/ui/item.rs:38:25
    |
-23 | #[derive_where(Clone; T U)]
+38 | #[derive_where(Clone; T U)]
    |                         ^
 
 error: unexpected option syntax
-  --> tests/ui/item.rs:26:16
+  --> tests/ui/item.rs:41:16
    |
-26 | #[derive_where("Clone")]
+41 | #[derive_where("Clone")]
    |                ^^^^^^^

--- a/non-msrv-tests/tests/ui/not-zeroize/item.stderr
+++ b/non-msrv-tests/tests/ui/not-zeroize/item.stderr
@@ -1,34 +1,34 @@
-error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
  --> tests/ui/not-zeroize/item.rs:5:16
   |
 5 | #[derive_where(skip_inner, Clone)]
   |                ^^^^^^^^^^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
  --> tests/ui/not-zeroize/item.rs:8:24
   |
 8 | #[derive_where(Debug = invalid; T)]
   |                        ^^^^^^^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
   --> tests/ui/not-zeroize/item.rs:11:16
    |
 11 | #[derive_where(,)]
    |                ^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
   --> tests/ui/not-zeroize/item.rs:14:16
    |
 14 | #[derive_where(,Clone)]
    |                ^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
   --> tests/ui/not-zeroize/item.rs:17:22
    |
 17 | #[derive_where(Clone,,)]
    |                      ^
 
-error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
   --> tests/ui/not-zeroize/item.rs:20:16
    |
 20 | #[derive_where(T)]

--- a/non-msrv-tests/tests/ui/zeroize/item.stderr
+++ b/non-msrv-tests/tests/ui/zeroize/item.stderr
@@ -1,34 +1,34 @@
-error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
  --> tests/ui/zeroize/item.rs:5:16
   |
 5 | #[derive_where(skip_inner, Clone)]
   |                ^^^^^^^^^^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
  --> tests/ui/zeroize/item.rs:8:24
   |
 8 | #[derive_where(Debug = invalid; T)]
   |                        ^^^^^^^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:11:16
    |
 11 | #[derive_where(,)]
    |                ^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:14:16
    |
 14 | #[derive_where(,Clone)]
    |                ^
 
-error: unsupported trait syntax, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:17:22
    |
 17 | #[derive_where(Clone,,)]
    |                      ^
 
-error: unsupported trait, expected one of expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:20:16
    |
 20 | #[derive_where(T)]

--- a/non-msrv-tests/tests/ui/zeroize/zeroize.rs
+++ b/non-msrv-tests/tests/ui/zeroize/zeroize.rs
@@ -17,9 +17,12 @@ struct WrongOptionSyntax2<T>(PhantomData<T>);
 struct WrongCrateSyntax<T>(PhantomData<T>);
 
 #[derive_where(Zeroize(crate = "struct Test"))]
-struct InvalidCrate<T>(PhantomData<T>);
+struct InvalidPath<T>(PhantomData<T>);
 
 #[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_"))]
 struct DuplicateCrate<T>(PhantomData<T>);
+
+#[derive_where(Zeroize(crate = "::zeroize"))]
+struct DefaultCrate<T>(PhantomData<T>);
 
 fn main() {}

--- a/non-msrv-tests/tests/ui/zeroize/zeroize.stderr
+++ b/non-msrv-tests/tests/ui/zeroize/zeroize.stderr
@@ -33,3 +33,9 @@ error: duplicate `crate` option
    |
 22 | #[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_"))]
    |                                            ^^^^^^^^^^^^^^^^^^
+
+error: unnecessary path qualification, `::zeroize` is used by default
+  --> tests/ui/zeroize/zeroize.rs:25:32
+   |
+25 | #[derive_where(Zeroize(crate = "::zeroize"))]
+   |                                ^^^^^^^^^^^

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -54,8 +54,8 @@ impl ItemAttr {
 										// Don't parse `Skip` yet, because it needs access to all
 										// `DeriveWhere`s.
 										skip_inners.push(meta);
-									} else if let Meta::NameValue(name_value) = meta {
-										if name_value.path.is_ident("crate") {
+									} else if meta.path().is_ident("crate") {
+										if let Meta::NameValue(name_value) = meta {
 											if let Lit::Str(lit_str) = &name_value.lit {
 												match lit_str.parse::<Path>() {
 													Ok(path) => {
@@ -93,7 +93,7 @@ impl ItemAttr {
 												));
 											}
 										} else {
-											return Err(Error::option_syntax(name_value.span()));
+											return Err(Error::option_syntax(meta.span()));
 										}
 									}
 									// The list can have one item but still not be the `skip_inner`

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,34 @@ use proc_macro2::Span;
 pub struct Error;
 
 impl Error {
+	/// `derive_where` was already applied on this item before.
+	pub fn visited(span: Span) -> syn::Error {
+		syn::Error::new(
+			span,
+			"`#[derive_where(..)` was already applied to this item before, this occurs when using \
+			 a qualified path for any `#[derive_where(..)`s except the first",
+		)
+	}
+
+	/// Unnecessary `crate` option because it is equal to the default.
+	pub fn path_unnecessary(span: Span, default: &str) -> syn::Error {
+		syn::Error::new(
+			span,
+			format!(
+				"unnecessary path qualification, `{}` is used by default",
+				default
+			),
+		)
+	}
+
+	/// The `crate` option was defined together with traits.
+	pub fn crate_(span: Span) -> syn::Error {
+		syn::Error::new(
+			span,
+			"the `crate` option has to be defined in it's own `#[derive_where(..)` attribute",
+		)
+	}
+
 	/// No `derive_where` with [`Trait`](crate::Trait) found.
 	pub fn none(span: Span) -> syn::Error {
 		syn::Error::new(
@@ -144,8 +172,7 @@ impl Error {
 		syn::Error::new(span, "trait to be skipped isn't being implemented")
 	}
 
-	/// Invalid value for the `Zeroize` `crate` option.
-	#[cfg(feature = "zeroize")]
+	/// Invalid value for the `derive_where` or `Zeroize` `crate` option.
 	pub fn path(span: Span, parse_error: syn::Error) -> syn::Error {
 		syn::Error::new(span, format!("expected path, {}", parse_error))
 	}
@@ -154,10 +181,7 @@ impl Error {
 	pub fn trait_(span: Span) -> syn::Error {
 		syn::Error::new(
 			span,
-			format!(
-				"unsupported trait, expected one of expected one of {}",
-				Self::trait_list()
-			),
+			format!("unsupported trait, expected one of {}", Self::trait_list()),
 		)
 	}
 
@@ -166,7 +190,7 @@ impl Error {
 		syn::Error::new(
 			span,
 			format!(
-				"unsupported trait syntax, expected one of expected one of {}",
+				"unsupported trait syntax, expected one of {}",
 				Self::trait_list()
 			),
 		)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@
 //!   [`unreachable`].
 //! - `zeroize`: Allows deriving [`Zeroize`] and [`method@zeroize`] on [`Drop`].
 //! - `zeroize-on-drop`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`] and
-//!   requires [zeroize] v1.5.0-pre.
+//!   requires [zeroize] v1.5.0.
 //!
 //! # MSRV
 //!
@@ -326,12 +326,12 @@
 //! [CHANGELOG]: https://github.com/ModProg/derive-where/blob/main/CHANGELOG.md
 //! [LICENSE-MIT]: https://github.com/ModProg/derive-where/blob/main/LICENSE-MIT
 //! [LICENSE-APACHE]: https://github.com/ModProg/derive-where/blob/main/LICENSE-APACHE
-//! [zeroize]: https://crates.io/crates/zeroize/1.5.0-pre
+//! [zeroize]: https://crates.io/crates/zeroize/1.5.0
 //! [`Debug`]: core::fmt::Debug
 //! [`Default`]: core::default::Default
 //! [`Hash`]: core::hash::Hash
 //! [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
-//! [`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5.0-pre/zeroize/trait.ZeroizeOnDrop.html
+//! [`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5.0/zeroize/trait.ZeroizeOnDrop.html
 //! [`method@zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
 //! [#27]: https://github.com/ModProg/derive-where/issues/27
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -37,6 +37,7 @@ fn derive_where_internal(input: TokenStream) -> Result<TokenStream> {
 		derive_wheres,
 		generics,
 		item,
+		..
 	} = Input::from_input(span, &item)?;
 
 	Ok(derive_wheres

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -89,6 +89,7 @@ impl Trait {
 				"Zeroize" => Ok(Zeroize),
 				#[cfg(feature = "zeroize")]
 				"ZeroizeOnDrop" => Ok(ZeroizeOnDrop),
+				"crate" => Err(Error::crate_(path.span())),
 				_ => Err(Error::trait_(path.span())),
 			}
 		} else {

--- a/src/trait_/zeroize.rs
+++ b/src/trait_/zeroize.rs
@@ -2,9 +2,9 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{spanned::Spanned, Lit, Meta, MetaList, NestedMeta, Result};
+use syn::{spanned::Spanned, Lit, Meta, MetaList, NestedMeta, Path, Result};
 
-use crate::{Data, DeriveTrait, Error, Item, SimpleType, TraitImpl};
+use crate::{util, Data, DeriveTrait, Error, Item, SimpleType, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) .
 pub struct Zeroize;
@@ -38,8 +38,15 @@ impl TraitImpl for Zeroize {
 						// Check for duplicate `crate` option.
 						if crate_.is_none() {
 							if let Lit::Str(lit_str) = &name_value.lit {
-								match lit_str.parse() {
+								match lit_str.parse::<Path>() {
 									Ok(path) => {
+										if path == util::path_from_strs(&["zeroize"]) {
+											return Err(Error::path_unnecessary(
+												path.span(),
+												"::zeroize",
+											));
+										}
+
 										crate_ = Some(path);
 									}
 									Err(error) => return Err(Error::path(lit_str.span(), error)),

--- a/src/trait_/zeroize_on_drop.rs
+++ b/src/trait_/zeroize_on_drop.rs
@@ -34,8 +34,15 @@ impl TraitImpl for ZeroizeOnDrop {
 						// Check for duplicate `crate` option.
 						if crate_.is_none() {
 							if let Lit::Str(lit_str) = &name_value.lit {
-								match lit_str.parse() {
+								match lit_str.parse::<Path>() {
 									Ok(path) => {
+										if path == util::path_from_strs(&["zeroize"]) {
+											return Err(Error::path_unnecessary(
+												path.span(),
+												"::zeroize",
+											));
+										}
+
 										crate_ = Some(path);
 									}
 									Err(error) => return Err(Error::path(lit_str.span(), error)),


### PR DESCRIPTION
This addresses a suggestion I made in #36. It implements a placeholder attribute that is applies when a `derive_where` attribute is processed. Any subsequent calls to `derive_where` with different paths will error out when they find this attribute.

Additionally:
- Adds a `#[derive_where(crate = "derive_where_")]` option.
- Fixes some typos.
- Adds a check for `#[derive_where(Zeroize(crate = "::zeroize"))]` because this is already the default.
- Update zeroize.