### PR TITLE
Derive forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ first one must use any path qualifications.
 struct Example1<T>(PhantomData<T>);
 ```
 
+If using a different package name, you must specify this:
+
+```rust
+#[derive_where(crate = "derive_where_")]
+#[derive_where(Clone, Debug)]
+struct Example<T>(PhantomData<T>);
+```
+
 In addition, the following convenience options are available:
 
 ### Generic type bounds

--- a/non-msrv-tests/tests/ui/item.rs
+++ b/non-msrv-tests/tests/ui/item.rs
@@ -1,3 +1,5 @@
+extern crate derive_where as derive_where_;
+
 use std::marker::PhantomData;
 
 use derive_where::derive_where;

--- a/non-msrv-tests/tests/ui/item.stderr
+++ b/non-msrv-tests/tests/ui/item.stderr
@@ -1,95 +1,95 @@
 error: empty `derive_where` found
- --> tests/ui/item.rs:5:1
+ --> tests/ui/item.rs:7:1
   |
-5 | #[derive_where]
+7 | #[derive_where]
   | ^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: empty `derive_where` found
- --> tests/ui/item.rs:8:1
-  |
-8 | #[derive_where()]
-  | ^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/ui/item.rs:10:1
+   |
+10 | #[derive_where()]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected option syntax
-  --> tests/ui/item.rs:11:16
+  --> tests/ui/item.rs:13:16
    |
-11 | #[derive_where(crate(derive_where_))]
+13 | #[derive_where(crate(derive_where_))]
    |                ^^^^^^^^^^^^^^^^^^^^
 
 error: expected path, expected identifier
-  --> tests/ui/item.rs:14:24
+  --> tests/ui/item.rs:16:24
    |
-14 | #[derive_where(crate = "struct Test")]
+16 | #[derive_where(crate = "struct Test")]
    |                        ^^^^^^^^^^^^^
 
 error: the `crate` option has to be defined in it's own `#[derive_where(..)` attribute
-  --> tests/ui/item.rs:20:16
+  --> tests/ui/item.rs:22:16
    |
-20 | #[derive_where(crate = "derive_where_", crate = "derive_where_")]
+22 | #[derive_where(crate = "derive_where_", crate = "derive_where_")]
    |                ^^^^^
 
 error: duplicate `crate` option
-  --> tests/ui/item.rs:24:16
+  --> tests/ui/item.rs:26:16
    |
-24 | #[derive_where(crate = "derive_where_")]
+26 | #[derive_where(crate = "derive_where_")]
    |                ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no traits found to implement, use `#[derive_where(..)` to specify some
-  --> tests/ui/item.rs:28:1
+  --> tests/ui/item.rs:30:1
    |
-28 | struct OnlyCrate<T>(PhantomData<T>);
+30 | struct OnlyCrate<T>(PhantomData<T>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unnecessary path qualification, `::derive_where` is used by default
-  --> tests/ui/item.rs:30:24
+  --> tests/ui/item.rs:32:24
    |
-30 | #[derive_where(crate = "::derive_where")]
+32 | #[derive_where(crate = "::derive_where")]
    |                        ^^^^^^^^^^^^^^^^
 
 error: expected `,`
-  --> tests/ui/item.rs:33:24
+  --> tests/ui/item.rs:35:24
    |
-33 | #[derive_where(Clone; T;)]
+35 | #[derive_where(Clone; T;)]
    |                        ^
 
 error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:36:25
+  --> tests/ui/item.rs:38:25
    |
-36 | #[derive_where(Clone; T,,)]
+38 | #[derive_where(Clone; T,,)]
    |                         ^
 
 error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:39:23
+  --> tests/ui/item.rs:41:23
    |
-39 | #[derive_where(Clone; where)]
+41 | #[derive_where(Clone; where)]
    |                       ^^^^^
 
 error: expected `;` or `,
-  --> tests/ui/item.rs:42:22
+  --> tests/ui/item.rs:44:22
    |
-42 | #[derive_where(Clone Debug)]
+44 | #[derive_where(Clone Debug)]
    |                      ^^^^^
 
 error: expected `,`
-  --> tests/ui/item.rs:45:25
+  --> tests/ui/item.rs:47:25
    |
-45 | #[derive_where(Clone; T U)]
+47 | #[derive_where(Clone; T U)]
    |                         ^
 
 error: unexpected option syntax
-  --> tests/ui/item.rs:48:16
+  --> tests/ui/item.rs:50:16
    |
-48 | #[derive_where("Clone")]
+50 | #[derive_where("Clone")]
    |                ^^^^^^^
 
 error: `#[derive_where(..)` was already applied to this item before, this occurs when using a qualified path for any `#[derive_where(..)`s except the first
-  --> tests/ui/item.rs:51:1
+  --> tests/ui/item.rs:53:1
    |
-51 | #[derive_where(Clone)]
+53 | #[derive_where(Clone)]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/non-msrv-tests/tests/ui/union.stderr
+++ b/non-msrv-tests/tests/ui/union.stderr
@@ -17,4 +17,4 @@ note: required by a bound in `__AssertCopy`
    |
 10 | #[derive_where(Clone)]
    | ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__AssertCopy`
-   = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `::derive_where::DeriveWhere` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -7,7 +7,7 @@ use syn::{
 	parse::{discouraged::Speculative, Parse, ParseStream},
 	punctuated::Punctuated,
 	spanned::Spanned,
-	Attribute, Data, Ident, Lit, Meta, NestedMeta, Path, PredicateType, Result, Token, TraitBound,
+	Attribute, Data, Ident, Meta, NestedMeta, Path, PredicateType, Result, Token, TraitBound,
 	TraitBoundModifier, Type, TypeParamBound, TypePath, WhereClause, WherePredicate,
 };
 
@@ -16,8 +16,6 @@ use crate::{util, Error, Item, Skip, Trait, TraitImpl, DERIVE_WHERE};
 /// Attributes on item.
 #[derive(Default)]
 pub struct ItemAttr {
-	/// [`Path`] to this crate.
-	pub crate_: Option<Path>,
 	/// [`Trait`]s to skip all fields for.
 	pub skip_inner: Skip,
 	/// [`DeriveWhere`]s on this item.
@@ -55,46 +53,8 @@ impl ItemAttr {
 										// `DeriveWhere`s.
 										skip_inners.push(meta);
 									} else if meta.path().is_ident("crate") {
-										if let Meta::NameValue(name_value) = meta {
-											if let Lit::Str(lit_str) = &name_value.lit {
-												match lit_str.parse::<Path>() {
-													Ok(path) => {
-														if path
-															== util::path_from_strs(&[DERIVE_WHERE])
-														{
-															return Err(Error::path_unnecessary(
-																path.span(),
-																&format!("::{}", DERIVE_WHERE),
-															));
-														}
-
-														match self_.crate_ {
-															Some(_) => {
-																return Err(
-																	Error::option_duplicate(
-																		name_value.span(),
-																		"crate",
-																	),
-																)
-															}
-															None => self_.crate_ = Some(path),
-														}
-													}
-													Err(error) => {
-														return Err(Error::path(
-															lit_str.span(),
-															error,
-														))
-													}
-												}
-											} else {
-												return Err(Error::option_syntax(
-													name_value.lit.span(),
-												));
-											}
-										} else {
-											return Err(Error::option_syntax(meta.span()));
-										}
+										// Do nothing, we checked this before
+										// already.
 									}
 									// The list can have one item but still not be the `skip_inner`
 									// attribute, continue with parsing `DeriveWhere`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,19 +1,14 @@
 //! Parses [`DeriveInput`] into something more useful.
 
 use proc_macro2::Span;
-use syn::{DeriveInput, GenericParam, Generics, Path, Result};
+use syn::{DeriveInput, GenericParam, Generics, Result};
 
 #[cfg(feature = "zeroize")]
 use crate::DeriveTrait;
-use crate::{
-	util, Data, DeriveWhere, Either, Error, Item, ItemAttr, Trait, DERIVE_WHERE,
-	DERIVE_WHERE_VISITED,
-};
+use crate::{Data, DeriveWhere, Either, Error, Item, ItemAttr, Trait};
 
 /// Parsed input.
 pub struct Input<'a> {
-	/// [`Path`] to the `derive_where_visited` proc-macro.
-	pub derive_where_visited: Path,
 	/// `derive_where` attributes on the item.
 	pub derive_wheres: Vec<DeriveWhere>,
 	/// Generics necessary to define for an `impl`.
@@ -36,23 +31,9 @@ impl<'a> Input<'a> {
 	) -> Result<Self> {
 		// Parse `Attribute`s on item.
 		let ItemAttr {
-			crate_,
 			skip_inner,
 			derive_wheres,
 		} = ItemAttr::from_attrs(span, data, attrs)?;
-
-		// Build `derive_where_visited` path.
-		let derive_where_visited = util::path_from_root_and_strs(
-			crate_.unwrap_or_else(|| util::path_from_strs(&[DERIVE_WHERE])),
-			&[DERIVE_WHERE_VISITED],
-		);
-
-		// Check if we already parsed this item before.
-		for attr in attrs {
-			if attr.path == derive_where_visited {
-				return Err(Error::visited(span));
-			}
-		}
 
 		// Extract fields and variants of this item.
 		let item = match &data {
@@ -182,7 +163,6 @@ impl<'a> Input<'a> {
 		}
 
 		Ok(Self {
-			derive_where_visited,
 			derive_wheres,
 			generics,
 			item,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,17 @@
 //! struct Example1<T>(PhantomData<T>);
 //! ```
 //!
+//! If using a different package name, you must specify this:
+//!
+//! ```
+//! # extern crate derive_where as derive_where_;
+//! # use std::marker::PhantomData;
+//! # use derive_where::derive_where;
+//! #[derive_where(crate = "derive_where_")]
+//! #[derive_where(Clone, Debug)]
+//! struct Example<T>(PhantomData<T>);
+//! ```
+//!
 //! In addition, the following convenience options are available:
 //!
 //! ## Generic type bounds
@@ -387,6 +398,8 @@ const DERIVE_WHERE_INTERNAL: &str = "DeriveWhere";
 const DERIVE_WHERE_VISITED: &str = "derive_where_visited";
 
 /// Item-level options:
+/// - `#[derive_where(crate = "path")]`: Specify path to the `derive_where`
+///   crate.
 /// - `#[derive_where(Clone, ..; T, ..)]`: Specify traits to implement and
 ///   optionally bounds.
 ///   - `#[derive_where(Zeroize(crate = "path"))]`: Specify path to [`Zeroize`]

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -1,0 +1,13 @@
+use std::marker::PhantomData;
+
+use derive_where::derive_where;
+
+#[test]
+fn cfg() {
+	#[derive_where(Clone)]
+	struct Test<T> {
+		a: PhantomData<T>,
+		#[cfg(invalid)]
+		b: u8,
+	}
+}


### PR DESCRIPTION
This forwards the attribute proc-macro to a derive proc-macro, enabling correct `cfg` evaluation.