### PR TITLE
Improve `Clone` code generation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -212,6 +212,11 @@ impl Error {
 		syn::Error::new(span, format!("expected type to bind to, {}", parse_error))
 	}
 
+	/// Duplicate trait with the same bound.
+	pub fn trait_duplicate(span: Span) -> syn::Error {
+		syn::Error::new(span, "duplicate trait with the same bound")
+	}
+
 	/// Unsupported default option if [`Default`] isn't implemented.
 	pub fn default(span: Span) -> syn::Error {
 		syn::Error::new(
@@ -229,8 +234,7 @@ impl Error {
 		)
 	}
 
-	/// Missing `default` option on a variant when [`Default`] is implemented
-	/// for an enum.
+	/// Duplicate `default` option on a variant.
 	pub fn default_duplicate(span: Span) -> syn::Error {
 		syn::Error::new(span, "multiple `default` options in enum")
 	}

--- a/src/input.rs
+++ b/src/input.rs
@@ -132,7 +132,7 @@ impl<'a> Input<'a> {
 			// type parameters were found.
 
 			// Don't allow no use-case compared to std `derive`.
-			for trait_ in &derive_where.traits {
+			for (span, trait_) in derive_where.spans.iter().zip(&derive_where.traits) {
 				// `Default` is used on an enum.
 				if trait_ == Trait::Default && item.is_enum() {
 					continue;
@@ -147,7 +147,7 @@ impl<'a> Input<'a> {
 				{
 					// `Zeroize(crate = "..")` or `ZeroizeOnDrop(crate = "..")` is used.
 					if let DeriveTrait::Zeroize { crate_: Some(_) }
-					| DeriveTrait::ZeroizeOnDrop { crate_: Some(_) } = **trait_
+					| DeriveTrait::ZeroizeOnDrop { crate_: Some(_) } = *trait_
 					{
 						continue;
 					}
@@ -158,7 +158,7 @@ impl<'a> Input<'a> {
 					}
 				}
 
-				return Err(Error::use_case(trait_.span));
+				return Err(Error::use_case(*span));
 			}
 		}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,7 @@ fn generate_impl(
 	let mut where_clause = where_clause.map(Cow::Borrowed);
 	derive_where.where_clause(&mut where_clause, trait_, item);
 
-	let body = generate_body(trait_, item);
+	let body = generate_body(&derive_where.traits, trait_, item);
 
 	let ident = item.ident();
 	let path = trait_.impl_path(trait_);
@@ -593,19 +593,19 @@ fn generate_impl(
 }
 
 /// Generate implementation method body for a [`Trait`].
-fn generate_body(trait_: &DeriveTrait, item: &Item) -> TokenStream {
+fn generate_body(traits: &[DeriveTrait], trait_: &DeriveTrait, item: &Item) -> TokenStream {
 	match &item {
 		Item::Item(data) => {
-			let body = trait_.build_body(trait_, data);
-			trait_.build_signature(item, trait_, &body)
+			let body = trait_.build_body(traits, trait_, data);
+			trait_.build_signature(item, traits, trait_, &body)
 		}
 		Item::Enum { variants, .. } => {
 			let body: TokenStream = variants
 				.iter()
-				.map(|data| trait_.build_body(trait_, data))
+				.map(|data| trait_.build_body(traits, trait_, data))
 				.collect();
 
-			trait_.build_signature(item, trait_, &body)
+			trait_.build_signature(item, traits, trait_, &body)
 		}
 	}
 }

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -11,8 +11,7 @@ fn struct_() -> Result<()> {
 			struct Test<T> { field: std::marker::PhatomData<T> }
 		},
 		quote! {
-			impl<T> ::core::clone::Clone for Test<T>
-			{
+			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
 					*self
@@ -22,8 +21,7 @@ fn struct_() -> Result<()> {
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 
-			impl<T> ::core::fmt::Debug for Test<T>
-			{
+			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
 						Test { field: ref __field } => {
@@ -35,8 +33,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::default::Default for Test<T>
-			{
+			impl<T> ::core::default::Default for Test<T> {
 				fn default() -> Self {
 					Test { field: ::core::default::Default::default() }
 				}
@@ -45,8 +42,7 @@ fn struct_() -> Result<()> {
 			impl<T> ::core::cmp::Eq for Test<T>
 			{ }
 
-			impl<T> ::core::hash::Hash for Test<T>
-			{
+			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
 						Test { field: ref __field } => { ::core::hash::Hash::hash(__field, __state); }
@@ -54,8 +50,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::Ord for Test<T>
-			{
+			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
 					match (self, __other) {
@@ -68,8 +63,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					match (self, __other) {
@@ -79,8 +73,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					match (self, __other) {
@@ -104,8 +97,7 @@ fn tuple() -> Result<()> {
 			struct Test<T>(std::marker::PhatomData<T>);
 		},
 		quote! {
-			impl<T> ::core::clone::Clone for Test<T>
-			{
+			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
 					*self
@@ -115,8 +107,7 @@ fn tuple() -> Result<()> {
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 
-			impl<T> ::core::fmt::Debug for Test<T>
-			{
+			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
 						Test(ref __0) => {
@@ -128,8 +119,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::default::Default for Test<T>
-			{
+			impl<T> ::core::default::Default for Test<T> {
 				fn default() -> Self {
 					Test(::core::default::Default::default())
 				}
@@ -138,8 +128,7 @@ fn tuple() -> Result<()> {
 			impl<T> ::core::cmp::Eq for Test<T>
 			{ }
 
-			impl<T> ::core::hash::Hash for Test<T>
-			{
+			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
 						Test(ref __0) => { ::core::hash::Hash::hash(__0, __state); }
@@ -147,8 +136,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::Ord for Test<T>
-			{
+			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
 					match (self, __other) {
@@ -161,8 +149,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					match (self, __other) {
@@ -172,8 +159,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					match (self, __other) {
@@ -282,8 +268,7 @@ fn enum_() -> Result<()> {
 			}
 		},
 		quote! {
-			impl<T> ::core::clone::Clone for Test<T>
-			{
+			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
 					*self
@@ -293,8 +278,7 @@ fn enum_() -> Result<()> {
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 
-			impl<T> ::core::fmt::Debug for Test<T>
-			{
+			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
 						Test::A { field: ref __field } => {
@@ -320,8 +304,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::default::Default for Test<T>
-			{
+			impl<T> ::core::default::Default for Test<T> {
 				fn default() -> Self {
 					Test::E
 				}
@@ -330,8 +313,7 @@ fn enum_() -> Result<()> {
 			impl<T> ::core::cmp::Eq for Test<T>
 			{ }
 
-			impl<T> ::core::hash::Hash for Test<T>
-			{
+			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
 						Test::A { field: ref __field } => {
@@ -355,8 +337,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::Ord for Test<T>
-			{
+			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
 					#discriminant
@@ -381,8 +362,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					if ::core::mem::discriminant(self) == ::core::mem::discriminant(__other) {
@@ -399,8 +379,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					#discriminant
@@ -439,8 +418,7 @@ fn union_() -> Result<()> {
 			}
 		},
 		quote! {
-			impl<T> ::core::clone::Clone for Test<T>
-			{
+			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
 					*self

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -15,9 +15,7 @@ fn struct_() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					match self {
-						Test { field: ref __field } => Test { field: ::core::clone::Clone::clone(__field) },
-					}
+					*self
 				}
 			}
 
@@ -110,9 +108,7 @@ fn tuple() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					match self {
-						Test(ref __0) => Test(::core::clone::Clone::clone(__0)),
-					}
+					*self
 				}
 			}
 
@@ -290,13 +286,7 @@ fn enum_() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					match self {
-						Test::A { field: ref __field } => Test::A { field: ::core::clone::Clone::clone(__field) },
-						Test::B { } => Test::B { },
-						Test::C(ref __0) => Test::C(::core::clone::Clone::clone(__0)),
-						Test::D() => Test::D(),
-						Test::E => Test::E,
-					}
+					*self
 				}
 			}
 
@@ -453,8 +443,6 @@ fn union_() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					struct __AssertCopy<__T: ::core::marker::Copy + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-					let _: __AssertCopy<Self>;
 					*self
 				}
 			}

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -152,9 +152,7 @@ fn check_trait_bounds() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					match self {
-						Test(ref __0, ref __1) => Test(::core::clone::Clone::clone(__0), ::core::clone::Clone::clone(__1)),
-					}
+					*self
 				}
 			}
 
@@ -270,9 +268,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					match self {
-						Test(ref __0, ref __1) => Test(::core::clone::Clone::clone(__0), ::core::clone::Clone::clone(__1)),
-					}
+					*self
 				}
 			}
 

--- a/src/test/clone.rs
+++ b/src/test/clone.rs
@@ -1,0 +1,96 @@
+use quote::quote;
+use syn::Result;
+
+use super::test_derive;
+
+#[test]
+fn struct_() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone)]
+			struct Test<T> { field: std::marker::PhatomData<T> }
+		},
+		quote! {
+			impl<T> ::core::clone::Clone for Test<T> {
+				#[inline]
+				fn clone(&self) -> Self {
+					match self {
+						Test { field: ref __field } => Test { field: ::core::clone::Clone::clone(__field) },
+					}
+				}
+			}
+		},
+	)
+}
+
+#[test]
+fn tuple() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone)]
+			struct Test<T>(std::marker::PhatomData<T>);
+		},
+		quote! {
+			impl<T> ::core::clone::Clone for Test<T> {
+				#[inline]
+				fn clone(&self) -> Self {
+					match self {
+						Test(ref __0) => Test(::core::clone::Clone::clone(__0)),
+					}
+				}
+			}
+		},
+	)
+}
+
+#[test]
+fn enum_() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone)]
+			enum Test<T> {
+				A { field: std::marker::PhatomData<T>},
+				B { },
+				C(std::marker::PhatomData<T>),
+				D(),
+				E,
+			}
+		},
+		quote! {
+			impl<T> ::core::clone::Clone for Test<T> {
+				#[inline]
+				fn clone(&self) -> Self {
+					match self {
+						Test::A { field: ref __field } => Test::A { field: ::core::clone::Clone::clone(__field) },
+						Test::B { } => Test::B { },
+						Test::C(ref __0) => Test::C(::core::clone::Clone::clone(__0)),
+						Test::D() => Test::D(),
+						Test::E => Test::E,
+					}
+				}
+			}
+		},
+	)
+}
+
+#[test]
+fn union_() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone)]
+			union Test<T> {
+				a: std::marker::PhantomData<T>,
+				b: u8,
+			}
+		},
+		quote! {
+			impl<T> ::core::clone::Clone for Test<T> {
+				#[inline]
+				fn clone(&self) -> Self {
+					struct __AssertCopy<__T: ::core::marker::Copy + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+					let _: __AssertCopy<Self>;
+				}
+			}
+		},
+	)
+}

--- a/src/test/enum_.rs
+++ b/src/test/enum_.rs
@@ -78,8 +78,7 @@ fn one_data() -> Result<()> {
 			enum Test<T> { A(std::marker::PhantomData<T>) }
 		},
 		quote! {
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					match (self, __other) {
@@ -89,8 +88,7 @@ fn one_data() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					match (self, __other) {
@@ -147,8 +145,7 @@ fn two_data() -> Result<()> {
 			enum Test<T> { A(std::marker::PhantomData<T>), B(std::marker::PhantomData<T>) }
 		},
 		quote! {
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					if ::core::mem::discriminant(self) == ::core::mem::discriminant(__other) {
@@ -165,8 +162,7 @@ fn two_data() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					#discriminant
@@ -231,8 +227,7 @@ fn unit() -> Result<()> {
 			enum Test<T> { A(std::marker::PhantomData<T>), B }
 		},
 		quote! {
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					if ::core::mem::discriminant(self) == ::core::mem::discriminant(__other) {
@@ -247,8 +242,7 @@ fn unit() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					#discriminant
@@ -308,8 +302,7 @@ fn struct_unit() -> Result<()> {
 			enum Test<T> { A(std::marker::PhantomData<T>), B { } }
 		},
 		quote! {
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					if ::core::mem::discriminant(self) == ::core::mem::discriminant(__other) {
@@ -324,8 +317,7 @@ fn struct_unit() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					#discriminant
@@ -385,8 +377,7 @@ fn tuple_unit() -> Result<()> {
 			enum Test<T> { A(std::marker::PhantomData<T>), B() }
 		},
 		quote! {
-			impl<T> ::core::cmp::PartialEq for Test<T>
-			{
+			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					if ::core::mem::discriminant(self) == ::core::mem::discriminant(__other) {
@@ -401,8 +392,7 @@ fn tuple_unit() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::PartialOrd for Test<T>
-			{
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
 					#discriminant

--- a/src/test/skip.rs
+++ b/src/test/skip.rs
@@ -12,8 +12,7 @@ fn struct_inner() -> Result<()> {
 			struct Test<T>(std::marker::PhatomData<T>);
 		},
 		quote! {
-			impl<T> ::core::fmt::Debug for Test<T>
-			{
+			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
 						Test(ref __0) => {
@@ -38,8 +37,7 @@ fn enum_inner() -> Result<()> {
 			}
 		},
 		quote! {
-			impl<T> ::core::fmt::Debug for Test<T>
-			{
+			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
 						Test::A(ref __0) => {
@@ -62,8 +60,7 @@ fn struct_empty() -> Result<()> {
 			struct Test<T>(std::marker::PhatomData<T>);
 		},
 		quote! {
-			impl<T> ::core::cmp::Ord for Test<T>
-			{
+			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
 					::core::cmp::Ordering::Equal
@@ -84,8 +81,7 @@ fn variant_empty() -> Result<()> {
 			}
 		},
 		quote! {
-			impl<T> ::core::cmp::Ord for Test<T>
-			{
+			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
 					::core::cmp::Ordering::Equal
@@ -138,8 +134,7 @@ fn variants_empty() -> Result<()> {
 			}
 		},
 		quote! {
-			impl<T> ::core::cmp::Ord for Test<T>
-			{
+			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
 					#discriminant
@@ -197,8 +192,7 @@ fn variants_partly_empty() -> Result<()> {
 			}
 		},
 		quote! {
-			impl<T> ::core::cmp::Ord for Test<T>
-			{
+			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
 					#discriminant

--- a/src/test/zeroize.rs
+++ b/src/test/zeroize.rs
@@ -11,8 +11,7 @@ fn basic() -> Result<()> {
 			struct Test<T>(std::marker::PhantomData<T>);
 		},
 		quote! {
-			impl<T> ::zeroize::Zeroize for Test<T>
-			{
+			impl<T> ::zeroize::Zeroize for Test<T> {
 				fn zeroize(&mut self) {
 					use ::zeroize::Zeroize;
 
@@ -204,8 +203,7 @@ fn fqs() -> Result<()> {
 			struct Test<T>(#[derive_where(Zeroize(fqs))] std::marker::PhantomData<T>);
 		},
 		quote! {
-			impl<T> ::zeroize::Zeroize for Test<T>
-			{
+			impl<T> ::zeroize::Zeroize for Test<T> {
 				fn zeroize(&mut self) {
 					use ::zeroize::Zeroize;
 

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -134,14 +134,16 @@ impl TraitImpl for Trait {
 	fn build_signature(
 		&self,
 		item: &Item,
+		traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
-		self.implementation().build_signature(item, trait_, body)
+		self.implementation()
+			.build_signature(item, traits, trait_, body)
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
-		self.implementation().build_body(trait_, data)
+	fn build_body(&self, traits: &[DeriveTrait], trait_: &DeriveTrait, data: &Data) -> TokenStream {
+		self.implementation().build_body(traits, trait_, data)
 	}
 }
 
@@ -190,6 +192,7 @@ pub trait TraitImpl {
 	fn build_signature(
 		&self,
 		_item: &Item,
+		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		_body: &TokenStream,
 	) -> TokenStream {
@@ -197,7 +200,12 @@ pub trait TraitImpl {
 	}
 
 	/// Build method body for this [`Trait`].
-	fn build_body(&self, _trait_: &DeriveTrait, _data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		_trait_: &DeriveTrait,
+		_data: &Data,
+	) -> TokenStream {
 		TokenStream::new()
 	}
 }

--- a/src/trait_/debug.rs
+++ b/src/trait_/debug.rs
@@ -25,6 +25,7 @@ impl TraitImpl for Debug {
 	fn build_signature(
 		&self,
 		_item: &Item,
+		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -37,7 +38,12 @@ impl TraitImpl for Debug {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		let self_pattern = &data.self_pattern();
 		let debug_name = data.ident.to_string();
 

--- a/src/trait_/default.rs
+++ b/src/trait_/default.rs
@@ -21,6 +21,7 @@ impl TraitImpl for Default {
 	fn build_signature(
 		&self,
 		_item: &Item,
+		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -31,7 +32,12 @@ impl TraitImpl for Default {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		if data.is_default() {
 			let path = &data.path;
 

--- a/src/trait_/hash.rs
+++ b/src/trait_/hash.rs
@@ -25,6 +25,7 @@ impl TraitImpl for Hash {
 	fn build_signature(
 		&self,
 		_item: &Item,
+		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -37,7 +38,12 @@ impl TraitImpl for Hash {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		let self_pattern = data.self_pattern();
 		let trait_path = trait_.path();
 

--- a/src/trait_/ord.rs
+++ b/src/trait_/ord.rs
@@ -25,6 +25,7 @@ impl TraitImpl for Ord {
 	fn build_signature(
 		&self,
 		item: &Item,
+		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -38,7 +39,12 @@ impl TraitImpl for Ord {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		if data.is_empty(trait_) {
 			TokenStream::new()
 		} else {

--- a/src/trait_/partial_eq.rs
+++ b/src/trait_/partial_eq.rs
@@ -25,6 +25,7 @@ impl TraitImpl for PartialEq {
 	fn build_signature(
 		&self,
 		item: &Item,
+		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -89,7 +90,12 @@ impl TraitImpl for PartialEq {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		if data.is_empty(trait_) {
 			TokenStream::new()
 		} else {

--- a/src/trait_/partial_ord.rs
+++ b/src/trait_/partial_ord.rs
@@ -26,6 +26,7 @@ impl TraitImpl for PartialOrd {
 	fn build_signature(
 		&self,
 		item: &Item,
+		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -39,7 +40,12 @@ impl TraitImpl for PartialOrd {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		if data.is_empty(trait_) {
 			TokenStream::new()
 		} else {

--- a/src/trait_/zeroize.rs
+++ b/src/trait_/zeroize.rs
@@ -77,6 +77,7 @@ impl TraitImpl for Zeroize {
 	fn build_signature(
 		&self,
 		item: &Item,
+		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -99,7 +100,12 @@ impl TraitImpl for Zeroize {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		if data.is_empty(trait_) {
 			TokenStream::new()
 		} else {

--- a/src/trait_/zeroize_on_drop.rs
+++ b/src/trait_/zeroize_on_drop.rs
@@ -85,6 +85,7 @@ impl TraitImpl for ZeroizeOnDrop {
 	fn build_signature(
 		&self,
 		item: &Item,
+		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -129,7 +130,12 @@ impl TraitImpl for ZeroizeOnDrop {
 		}
 	}
 
-	fn build_body(&self, trait_: &DeriveTrait, data: &Data) -> TokenStream {
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
 		if data.is_empty(trait_) {
 			TokenStream::new()
 		} else {

--- a/tests/ui/item.rs
+++ b/tests/ui/item.rs
@@ -54,4 +54,11 @@ struct InvalidTrait<T>(PhantomData<T>);
 #[derive_where::derive_where(Copy)]
 struct QualifiedNotFirstMacro<T>(PhantomData<T>);
 
+#[derive_where(Clone, Clone)]
+struct DuplicateTrait1<T>(PhantomData<T>);
+
+#[derive_where(Clone)]
+#[derive_where(Clone)]
+struct DuplicateTrait2<T>(PhantomData<T>);
+
 fn main() {}

--- a/tests/ui/item.stderr
+++ b/tests/ui/item.stderr
@@ -93,3 +93,15 @@ error: `#[derive_where(..)` was already applied to this item before, this occurs
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: duplicate trait with the same bound
+  --> tests/ui/item.rs:57:23
+   |
+57 | #[derive_where(Clone, Clone)]
+   |                       ^^^^^
+
+error: duplicate trait with the same bound
+  --> tests/ui/item.rs:61:16
+   |
+61 | #[derive_where(Clone)]
+   |                ^^^^^


### PR DESCRIPTION
This mimics what Rust `std` does, when we know that `Copy` is implemented, no further code is required for `Clone`.

To make sure that we consider `Copy` implementation in separate `derive_where`s I made sure to merge `derive_where`s that have the same bounds beforehand.