### PR TITLE
Enforce `Eq` trait on field types

### DIFF
--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -39,8 +39,15 @@ fn struct_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::Eq for Test<T>
-			{ }
+			impl<T> ::core::cmp::Eq for Test<T> {
+				#[inline]
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// For some reason the comparison fails without the extra space at the end.
+					let _: __AssertEq<std::marker::PhatomData<T> >;
+				}
+			}
 
 			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
@@ -125,8 +132,15 @@ fn tuple() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::Eq for Test<T>
-			{ }
+			impl<T> ::core::cmp::Eq for Test<T> {
+				#[inline]
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// For some reason the comparison fails without the extra space at the end.
+					let _: __AssertEq<std::marker::PhatomData<T> >;
+				}
+			}
 
 			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
@@ -310,8 +324,16 @@ fn enum_() -> Result<()> {
 				}
 			}
 
-			impl<T> ::core::cmp::Eq for Test<T>
-			{ }
+			impl<T> ::core::cmp::Eq for Test<T> {
+				#[inline]
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// For some reason the comparison fails without the extra space at the end.
+					let _: __AssertEq<std::marker::PhatomData<T> >;
+					let _: __AssertEq<std::marker::PhatomData<T> >;
+				}
+			}
 
 			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -185,7 +185,16 @@ fn check_trait_bounds() -> Result<()> {
 
 			impl<T, U> ::core::cmp::Eq for Test<T, U>
 			where T: ::core::cmp::Eq
-			{ }
+			{
+				#[inline]
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// For some reason the comparison fails without the extra space at the end.
+					let _: __AssertEq<T >;
+					let _: __AssertEq<std::marker::PhatomData<U> >;
+				}
+			}
 
 			impl<T, U> ::core::hash::Hash for Test<T, U>
 			where T: ::core::hash::Hash
@@ -309,7 +318,16 @@ fn check_multiple_trait_bounds() -> Result<()> {
 			where
 				T: ::core::cmp::Eq,
 				U: ::core::cmp::Eq
-			{ }
+			{
+				#[inline]
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// For some reason the comparison fails without the extra space at the end.
+					let _: __AssertEq<T >;
+					let _: __AssertEq<std::marker::PhatomData<(U, V)> >;
+				}
+			}
 
 			impl<T, U, V> ::core::hash::Hash for Test<T, U, V>
 			where

--- a/src/trait_/eq.rs
+++ b/src/trait_/eq.rs
@@ -1,6 +1,9 @@
 //! [`Eq`](std::cmp::Eq) implementation.
 
-use crate::{DeriveTrait, TraitImpl};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::{Data, DeriveTrait, Item, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for [`Eq`](std::cmp::Eq).
 pub struct Eq;
@@ -12,5 +15,39 @@ impl TraitImpl for Eq {
 
 	fn default_derive_trait(&self) -> DeriveTrait {
 		DeriveTrait::Eq
+	}
+
+	fn supports_skip(&self) -> bool {
+		true
+	}
+
+	fn build_signature(
+		&self,
+		_item: &Item,
+		_traits: &[DeriveTrait],
+		_trait_: &DeriveTrait,
+		body: &TokenStream,
+	) -> TokenStream {
+		quote! {
+			#[inline]
+			fn assert_receiver_is_total_eq(&self) {
+				struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+				#body
+			}
+		}
+	}
+
+	fn build_body(
+		&self,
+		_traits: &[DeriveTrait],
+		trait_: &DeriveTrait,
+		data: &Data,
+	) -> TokenStream {
+		let types = data.iter_fields(trait_).map(|field| field.type_);
+
+		quote! {
+			#(let _: __AssertEq<#types>;)*
+		}
 	}
 }


### PR DESCRIPTION
Fixes #43. It does not only allow `skip`ing, but actually enforces `Eq` on every type like `std` does.