### PR TITLE
Add `derive_bounded` as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,11 @@ accompanied by a minor version bump. If MSRV is important to you, use
 
 ## Alternatives
 
-[derivative](https://crates.io/crates/derivative)
-([![Crates.io](https://img.shields.io/crates/v/derivative.svg)](https://crates.io/crates/derivative))
-is a great alternative with many options. Notably it doesn't support `no_std`
-and requires an extra `#[derive(Derivative)]` to use.
+- [derivative](https://crates.io/crates/derivative) [![Crates.io](https://img.shields.io/crates/v/derivative.svg)](https://crates.io/crates/derivative)
+  is a great alternative with many options. Notably it doesn't support
+  `no_std` and requires an extra `#[derive(Derivative)]` to use.
+- [derive_bounded](https://crates.io/crates/derive_bounded) [![Crates.io](https://img.shields.io/crates/v/derive_bounded.svg)](https://crates.io/crates/derive_bounded)
+  is a new alternative still in development.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ struct Example(#[derive_where(Zeroize(fqs))] i32);
 
 impl Example {
 	// If we didn't specify the `fqs` option, this would lead to a compile
-	//error because of method ambiguity.
+	// error because of method ambiguity.
 	fn zeroize(&mut self) {
 		self.0 = 1;
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@
 //!
 //! impl Example {
 //! 	// If we didn't specify the `fqs` option, this would lead to a compile
-//! 	//error because of method ambiguity.
+//! 	// error because of method ambiguity.
 //! 	fn zeroize(&mut self) {
 //! 		self.0 = 1;
 //! 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,10 +295,11 @@
 //!
 //! # Alternatives
 //!
-//! [derivative](https://crates.io/crates/derivative)
-//! ([![Crates.io](https://img.shields.io/crates/v/derivative.svg)](https://crates.io/crates/derivative))
-//! is a great alternative with many options. Notably it doesn't support
-//! `no_std` and requires an extra `#[derive(Derivative)]` to use.
+//! - [derivative](https://crates.io/crates/derivative) [![Crates.io](https://img.shields.io/crates/v/derivative.svg)](https://crates.io/crates/derivative)
+//!   is a great alternative with many options. Notably it doesn't support
+//!   `no_std` and requires an extra `#[derive(Derivative)]` to use.
+//! - [derive_bounded](https://crates.io/crates/derive_bounded) [![Crates.io](https://img.shields.io/crates/v/derive_bounded.svg)](https://crates.io/crates/derive_bounded)
+//!   is a new alternative still in development.
 //!
 //! # Changelog
 //!


### PR DESCRIPTION
Just discovered `derive_bounded`.
Fixed some spacing issue on the way, also removed the parentheses around the Crates.io label in the alternatives.

Cc https://github.com/lu-zero/derive_bounded/issues/2.