### PR TITLE
Improve Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ## Description
 
-Derive macro to simplify deriving standard and other traits with custom
-generic type bounds.
+Attribute proc-macro to simplify deriving standard and other traits with
+custom generic type bounds.
 
 ## Usage
 
-The `derive_where` macro can be used just like std's `#[derive(...)]`
+The `derive_where` attribute can be used just like std's `#[derive(...)]`
 statements:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Multiple `derive_where` attributes can be added to an item, but only the
 first one must use any path qualifications.
 
 ```rust
-#[derive_where::derive_where(Clone)]
-#[derive_where(Debug)]
+#[derive_where::derive_where(Clone, Debug)]
+#[derive_where(Eq, PartialEq)]
 struct Example1<T>(PhantomData<T>);
 ```
 
@@ -49,7 +49,7 @@ specified. This example will restrict the implementation for `Example` to
 `T: Clone`:
 
 ```rust
-#[derive_where(Clone; T)]
+#[derive_where(Clone, Debug; T)]
 struct Example<T, U>(T, PhantomData<U>);
 ```
 
@@ -57,15 +57,15 @@ It is also possible to specify the bounds to be applied. This will
 bind implementation for `Example` to `T: Super`:
 
 ```rust
-trait Super: Clone {}
+trait Super: Clone + Debug {}
 
-#[derive_where(Clone; T: Super)]
+#[derive_where(Clone, Debug; T: Super)]
 struct Example<T>(PhantomData<T>);
 ```
 
 But more complex trait bounds are possible as well.
-The example below will restrict the implementation for `Example` to
-`T::Type: Clone`:
+The example below will restrict the [`Clone`] implementation for `Example`
+to `T::Type: Clone`:
 
 ```rust
 trait Trait {
@@ -78,7 +78,7 @@ impl Trait for Impl {
 	type Type = i32;
 }
 
-#[derive_where(Clone; T::Type)]
+#[derive_where(Clone, Debug; T::Type)]
 struct Example<T: Trait>(T::Type);
 ```
 
@@ -87,8 +87,8 @@ specific constrain. It is also possible to use multiple separate
 constrain specifications when required:
 
 ```rust
-#[derive_where(Clone; T)]
-#[derive_where(Debug; U)]
+#[derive_where(Clone, Debug; T)]
+#[derive_where(Eq, PartialEq; U)]
 struct Example<T, U>(PhantomData<T>, PhantomData<U>);
 ```
 
@@ -99,7 +99,7 @@ Since Rust 1.62 deriving [`Default`] on an enum is possible with the
 `#[derive_where(default)]` attribute:
 
 ```rust
-#[derive_where(Default)]
+#[derive_where(Clone, Default)]
 enum Example<T> {
 	#[derive_where(default)]
 	A(PhantomData<T>),
@@ -123,19 +123,21 @@ assert_eq!(Example(42), Example(0));
 It is also possible to skip all fields in an item or variant if desired:
 
 ```rust
-#[derive_where(Debug)]
+#[derive_where(Debug, PartialEq)]
 #[derive_where(skip_inner)]
 struct StructExample<T>(T);
 
 assert_eq!(format!("{:?}", StructExample(42)), "StructExample");
+assert_eq!(StructExample(42), StructExample(0));
 
-#[derive_where(Debug)]
+#[derive_where(Debug, PartialEq)]
 enum EnumExample<T> {
 	#[derive_where(skip_inner)]
 	A(T),
 }
 
 assert_eq!(format!("{:?}", EnumExample::A(42)), "A");
+assert_eq!(EnumExample::A(42), EnumExample::A(0));
 ```
 
 Selective skipping of fields for certain traits is also an option, both in

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ custom generic type bounds.
 
 ## Usage
 
-The `derive_where` attribute can be used just like std's `#[derive(...)]`
-statements:
+The [`derive_where`] attribute can be used just like
+std's `#[derive(...)]` statements:
 
 ```rust
 #[derive_where(Clone, Debug)]
@@ -23,8 +23,8 @@ This will generate trait implementations for `Example` for any `T`,
 as opposed to std's derives, which would only implement these traits with
 `T: Trait` bound to the corresponding trait.
 
-Multiple `derive_where` attributes can be added to an item, but only the
-first one must use any path qualifications.
+Multiple [`derive_where`] attributes can be added to an
+item, but only the first one must use any path qualifications.
 
 ```rust
 #[derive_where::derive_where(Clone, Debug)]
@@ -109,8 +109,8 @@ enum Example<T> {
 ### Skipping fields
 
 With a `skip` or `skip_inner` attribute fields can be skipped for traits
-that allow it, which are: [`Debug`], [`Hash`], [`Ord`](https://doc.rust-lang.org/core/cmp/trait.Ord.html), [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html),
-[`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html), [`Zeroize`] and [`ZeroizeOnDrop`].
+that allow it, which are: [`Debug`], [`Hash`], [`Ord`], [`PartialOrd`],
+[`PartialEq`], [`Zeroize`] and [`ZeroizeOnDrop`].
 
 ```rust
 #[derive_where(Debug, PartialEq; T)]
@@ -164,12 +164,12 @@ assert_ne!(
 
 ### `Zeroize` options
 
-[`Zeroize`] has two options:
-- `crate`: an item-level option which specifies a path to the `zeroize`
+`Zeroize` has two options:
+- `crate`: an item-level option which specifies a path to the [`zeroize`]
   crate in case of a re-export or rename.
-- `fqs`: a field -level option which will use fully-qualified-syntax instead
-  of calling the [`zeroize`][`method@zeroize`] method on `self` directly.
-  This is to avoid ambiguity between another method also called `zeroize`.
+- `fqs`: a field-level option which will use fully-qualified-syntax instead
+  of calling the [`zeroize`][method@zeroize] method on `self` directly. This
+  is to avoid ambiguity between another method also called `zeroize`.
 
 ```rust
 #[derive_where(Zeroize(crate = "zeroize_"))]
@@ -198,10 +198,10 @@ assert_eq!(test.0, 0);
 
 If the `zeroize-on-drop` feature is enabled, it implements [`ZeroizeOnDrop`]
 and can be implemented without [`Zeroize`], otherwise it only implements
-[`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html) and requires [`Zeroize`] to be implemented.
+[`Drop`] and requires [`Zeroize`] to be implemented.
 
 [`ZeroizeOnDrop`] has one option:
-- `crate`: an item-level option which specifies a path to the `zeroize`
+- `crate`: an item-level option which specifies a path to the [`zeroize`]
   crate in case of a re-export or rename.
 
 ```rust
@@ -214,19 +214,19 @@ assert!(core::mem::needs_drop::<Example>());
 ### Supported traits
 
 The following traits can be derived with derive-where:
-- [`Clone`](https://doc.rust-lang.org/core/clone/trait.Clone.html)
-- [`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html)
+- [`Clone`]
+- [`Copy`]
 - [`Debug`]
 - [`Default`]
-- [`Eq`](https://doc.rust-lang.org/core/cmp/trait.Eq.html)
+- [`Eq`]
 - [`Hash`]
-- [`Ord`](https://doc.rust-lang.org/core/cmp/trait.Ord.html)
-- [`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html)
-- [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html)
+- [`Ord`]
+- [`PartialEq`]
+- [`PartialOrd`]
 - [`Zeroize`]: Only available with the `zeroize` crate feature.
 - [`ZeroizeOnDrop`]: Only available with the `zeroize` crate feature. If the
   `zeroize-on-drop` feature is enabled, it implements [`ZeroizeOnDrop`],
-  otherwise it only implements [`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html).
+  otherwise it only implements [`Drop`].
 
 ### Supported items
 
@@ -235,7 +235,7 @@ it's best to discourage usage that could be covered by std's `derive`. For
 example unit structs and enums only containing unit variants aren't
 supported.
 
-Unions only support [`Clone`](https://doc.rust-lang.org/core/clone/trait.Clone.html) and [`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html).
+Unions only support [`Clone`] and [`Copy`].
 
 ### `no_std` support
 
@@ -243,19 +243,20 @@ Unions only support [`Clone`](https://doc.rust-lang.org/core/clone/trait.Clone.h
 
 ## Crate features
 
-- `nightly`: Implements [`Ord`](https://doc.rust-lang.org/core/cmp/trait.Ord.html) and [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html) with the help of
-  [`core::intrinsics::discriminant_value`](https://doc.rust-lang.org/core/intrinsics/fn.discriminant_value.html), which is what Rust does by
-  default too. Without this feature [`transmute`](https://doc.rust-lang.org/core/mem/fn.transmute.html) is
-  used to convert [`Discriminant`](https://doc.rust-lang.org/core/mem/struct.Discriminant.html) to a [`i32`](https://doc.rust-lang.org/core/primitive.i32.html),
+- `nightly`: Implements [`Ord`] and [`PartialOrd`] with the help of
+  [`core::intrinsics::discriminant_value`], which is what Rust does by
+  default too. Without this feature [`transmute`] is
+  used to convert [`Discriminant`] to a [`i32`],
   which is the underlying type.
-- `safe`: Implements [`Ord`](https://doc.rust-lang.org/core/cmp/trait.Ord.html) and [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html) manually. This is much
+- `safe`: Implements [`Ord`] and [`PartialOrd`] manually. This is much
   slower, but might be preferred if you don't trust derive-where. It also
-  replaces all cases of [`core::hint::unreachable_unchecked`](https://doc.rust-lang.org/core/hint/fn.unreachable_unchecked.html) in [`Ord`](https://doc.rust-lang.org/core/hint/fn.unreachable_unchecked.html),
-  [`PartialEq`](https://doc.rust-lang.org/core/cmp/trait.PartialEq.html) and [`PartialOrd`](https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html), which is what std uses, with
-  [`unreachable`](https://doc.rust-lang.org/core/macro.unreachable.html).
-- `zeroize`: Allows deriving [`Zeroize`] and [`method@zeroize`] on [`Drop`](https://doc.rust-lang.org/core/ops/trait.Drop.html).
+  replaces all cases of [`core::hint::unreachable_unchecked`] in [`Ord`],
+  [`PartialEq`] and [`PartialOrd`], which is what std uses, with
+  [`unreachable`].
+- `zeroize`: Allows deriving [`Zeroize`] and [`zeroize`][method@zeroize] on
+  [`Drop`].
 - `zeroize-on-drop`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`] and
-  requires [zeroize] v1.5.
+  requires [`zeroize`] v1.5.
 
 ## MSRV
 
@@ -294,10 +295,25 @@ conditions.
 [CHANGELOG]: https://github.com/ModProg/derive-where/blob/main/CHANGELOG.md
 [LICENSE-MIT]: https://github.com/ModProg/derive-where/blob/main/LICENSE-MIT
 [LICENSE-APACHE]: https://github.com/ModProg/derive-where/blob/main/LICENSE-APACHE
-[zeroize]: https://crates.io/crates/zeroize/1.5.2
 [`Debug`]: https://doc.rust-lang.org/core/fmt/trait.Debug.html
 [`Default`]: https://doc.rust-lang.org/core/default/trait.Default.html
 [`Hash`]: https://doc.rust-lang.org/core/hash/trait.Hash.html
+[`zeroize`]: https://docs.rs/zeroize
 [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
-[`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5/zeroize/trait.ZeroizeOnDrop.html
-[`method@zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
+[`ZeroizeOnDrop`]: https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html
+[method@zeroize]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
+
+[`Clone`]: https://doc.rust-lang.org/core/clone/trait.Clone.html
+[`Copy`]: https://doc.rust-lang.org/core/marker/trait.Copy.html
+[`core::hint::unreachable_unchecked`]: https://doc.rust-lang.org/core/hint/fn.unreachable_unchecked.html
+[`core::intrinsics::discriminant_value`]: https://doc.rust-lang.org/core/intrinsics/fn.discriminant_value.html
+[`derive_where`]: https://docs.rs/derive-where/latest/derive_where/attr.derive_where.html
+[`Discriminant`]: https://doc.rust-lang.org/core/mem/struct.Discriminant.html
+[`Drop`]: https://doc.rust-lang.org/core/ops/trait.Drop.html
+[`Eq`]: https://doc.rust-lang.org/core/cmp/trait.Eq.html
+[`i32`]: https://doc.rust-lang.org/core/primitive.i32.html
+[`Ord`]: https://doc.rust-lang.org/core/cmp/trait.Ord.html
+[`PartialEq`]: https://doc.rust-lang.org/core/cmp/trait.PartialEq.html
+[`PartialOrd`]: https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html
+[`transmute`]: https://doc.rust-lang.org/core/mem/fn.transmute.html
+[`unreachable`]: https://doc.rust-lang.org/core/macro.unreachable.html

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ struct Example<T, U>(PhantomData<T>, PhantomData<U>);
 
 ### Enum default
 
-Deriving [`Default`] on an enum is not possible in Rust at the moment.
-Derive-where allows this with a `default` attribute:
+Since Rust 1.62 deriving [`Default`] on an enum is possible with the
+`#[default]` attribute. Derive-where allows this with a
+`#[derive_where(default)]` attribute:
 
 ```rust
 #[derive_where(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@
 
 //! # Description
 //!
-//! Derive macro to simplify deriving standard and other traits with custom
-//! generic type bounds.
+//! Attribute proc-macro to simplify deriving standard and other traits with
+//! custom generic type bounds.
 //!
 //! # Usage
 //!
-//! The `derive_where` macro can be used just like std's `#[derive(...)]`
+//! The `derive_where` attribute can be used just like std's `#[derive(...)]`
 //! statements:
 //!
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,9 @@
 //!
 //! ## Enum default
 //!
-//! Deriving [`Default`] on an enum is not possible in Rust at the moment.
-//! Derive-where allows this with a `default` attribute:
+//! Since Rust 1.62 deriving [`Default`] on an enum is possible with the
+//! `#[default]` attribute. Derive-where allows this with a
+//! `#[derive_where(default)]` attribute:
 //!
 //! ```
 //! # use std::marker::PhantomData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! # Usage
 //!
-//! The `derive_where` attribute can be used just like std's `#[derive(...)]`
-//! statements:
+//! The [`derive_where`](macro@derive_where) attribute can be used just like
+//! std's `#[derive(...)]` statements:
 //!
 //! ```
 //! # use std::marker::PhantomData;
@@ -25,8 +25,8 @@
 //! as opposed to std's derives, which would only implement these traits with
 //! `T: Trait` bound to the corresponding trait.
 //!
-//! Multiple `derive_where` attributes can be added to an item, but only the
-//! first one must use any path qualifications.
+//! Multiple [`derive_where`](macro@derive_where) attributes can be added to an
+//! item, but only the first one must use any path qualifications.
 //!
 //! ```
 //! # use std::marker::PhantomData;
@@ -187,12 +187,12 @@
 //!
 //! ## `Zeroize` options
 //!
-//! [`Zeroize`] has two options:
-//! - `crate`: an item-level option which specifies a path to the `zeroize`
+//! `Zeroize` has two options:
+//! - `crate`: an item-level option which specifies a path to the [`zeroize`]
 //!   crate in case of a re-export or rename.
-//! - `fqs`: a field -level option which will use fully-qualified-syntax instead
-//!   of calling the [`zeroize`][`method@zeroize`] method on `self` directly.
-//!   This is to avoid ambiguity between another method also called `zeroize`.
+//! - `fqs`: a field-level option which will use fully-qualified-syntax instead
+//!   of calling the [`zeroize`][method@zeroize] method on `self` directly. This
+//!   is to avoid ambiguity between another method also called `zeroize`.
 //!
 //! ```
 //! # #[cfg(feature = "zeroize")]
@@ -230,7 +230,7 @@
 //! [`Drop`] and requires [`Zeroize`] to be implemented.
 //!
 //! [`ZeroizeOnDrop`] has one option:
-//! - `crate`: an item-level option which specifies a path to the `zeroize`
+//! - `crate`: an item-level option which specifies a path to the [`zeroize`]
 //!   crate in case of a re-export or rename.
 //!
 //! ```
@@ -287,9 +287,10 @@
 //!   replaces all cases of [`core::hint::unreachable_unchecked`] in [`Ord`],
 //!   [`PartialEq`] and [`PartialOrd`], which is what std uses, with
 //!   [`unreachable`].
-//! - `zeroize`: Allows deriving [`Zeroize`] and [`method@zeroize`] on [`Drop`].
+//! - `zeroize`: Allows deriving [`Zeroize`] and [`zeroize`][method@zeroize] on
+//!   [`Drop`].
 //! - `zeroize-on-drop`: Allows deriving [`Zeroize`] and [`ZeroizeOnDrop`] and
-//!   requires [zeroize] v1.5.
+//!   requires [`zeroize`] v1.5.
 //!
 //! # MSRV
 //!
@@ -328,13 +329,13 @@
 //! [CHANGELOG]: https://github.com/ModProg/derive-where/blob/main/CHANGELOG.md
 //! [LICENSE-MIT]: https://github.com/ModProg/derive-where/blob/main/LICENSE-MIT
 //! [LICENSE-APACHE]: https://github.com/ModProg/derive-where/blob/main/LICENSE-APACHE
-//! [zeroize]: https://crates.io/crates/zeroize/1.5.2
 //! [`Debug`]: core::fmt::Debug
 //! [`Default`]: core::default::Default
 //! [`Hash`]: core::hash::Hash
+//! [`zeroize`]: https://docs.rs/zeroize
 //! [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
-//! [`ZeroizeOnDrop`]: https://docs.rs/zeroize/1.5/zeroize/trait.ZeroizeOnDrop.html
-//! [`method@zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
+//! [`ZeroizeOnDrop`]: https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html
+//! [method@zeroize]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize
 
 mod attr;
 mod data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@
 //!
 //! ```
 //! # use std::marker::PhantomData;
-//! #[derive_where::derive_where(Clone)]
-//! #[derive_where(Debug)]
+//! #[derive_where::derive_where(Clone, Debug)]
+//! #[derive_where(Eq, PartialEq)]
 //! struct Example1<T>(PhantomData<T>);
 //! ```
 //!
@@ -57,7 +57,7 @@
 //! ```
 //! # use std::marker::PhantomData;
 //! # use derive_where::derive_where;
-//! #[derive_where(Clone; T)]
+//! #[derive_where(Clone, Debug; T)]
 //! struct Example<T, U>(T, PhantomData<U>);
 //! ```
 //!
@@ -65,17 +65,18 @@
 //! bind implementation for `Example` to `T: Super`:
 //!
 //! ```
+//! # use std::fmt::Debug;
 //! # use std::marker::PhantomData;
 //! # use derive_where::derive_where;
-//! trait Super: Clone {}
+//! trait Super: Clone + Debug {}
 //!
-//! #[derive_where(Clone; T: Super)]
+//! #[derive_where(Clone, Debug; T: Super)]
 //! struct Example<T>(PhantomData<T>);
 //! ```
 //!
 //! But more complex trait bounds are possible as well.
-//! The example below will restrict the implementation for `Example` to
-//! `T::Type: Clone`:
+//! The example below will restrict the [`Clone`] implementation for `Example`
+//! to `T::Type: Clone`:
 //!
 //! ```
 //! # use std::marker::PhantomData;
@@ -90,7 +91,7 @@
 //! 	type Type = i32;
 //! }
 //!
-//! #[derive_where(Clone; T::Type)]
+//! #[derive_where(Clone, Debug; T::Type)]
 //! struct Example<T: Trait>(T::Type);
 //! ```
 //!
@@ -101,8 +102,8 @@
 //! ```
 //! # use std::marker::PhantomData;
 //! # use derive_where::derive_where;
-//! #[derive_where(Clone; T)]
-//! #[derive_where(Debug; U)]
+//! #[derive_where(Clone, Debug; T)]
+//! #[derive_where(Eq, PartialEq; U)]
 //! struct Example<T, U>(PhantomData<T>, PhantomData<U>);
 //! ```
 //!
@@ -115,7 +116,7 @@
 //! ```
 //! # use std::marker::PhantomData;
 //! # use derive_where::derive_where;
-//! #[derive_where(Default)]
+//! #[derive_where(Clone, Default)]
 //! enum Example<T> {
 //! 	#[derive_where(default)]
 //! 	A(PhantomData<T>),
@@ -143,19 +144,21 @@
 //! ```
 //! # use std::marker::PhantomData;
 //! # use derive_where::derive_where;
-//! #[derive_where(Debug)]
+//! #[derive_where(Debug, PartialEq)]
 //! #[derive_where(skip_inner)]
 //! struct StructExample<T>(T);
 //!
 //! assert_eq!(format!("{:?}", StructExample(42)), "StructExample");
+//! assert_eq!(StructExample(42), StructExample(0));
 //!
-//! #[derive_where(Debug)]
+//! #[derive_where(Debug, PartialEq)]
 //! enum EnumExample<T> {
 //! 	#[derive_where(skip_inner)]
 //! 	A(T),
 //! }
 //!
 //! assert_eq!(format!("{:?}", EnumExample::A(42)), "A");
+//! assert_eq!(EnumExample::A(42), EnumExample::A(0));
 //! ```
 //!
 //! Selective skipping of fields for certain traits is also an option, both in


### PR DESCRIPTION
I discovered in https://github.com/lu-zero/derive_bounded/issues/2 that the examples on the front page might lead users to believe you have to write a `#[derive_where(..)]` for each trait, I improved the examples to not only use one trait.

Also fixed some wording about `Default` on `enum`s, Rusts supports this now.

EDIT: Looking at the README again, I noticed a lot of links were broken and missing, so I fixed that too.