### PR TITLE
Update to `syn` v2

### DIFF
--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,6 +1,8 @@
-16
+18
+≥1
 Changelog
 CHANGELOG
+derive_bounded
 destructure/G
 enum/S
 FQS

--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,4 +1,4 @@
-15
+16
 Changelog
 CHANGELOG
 destructure/G
@@ -12,5 +12,6 @@ struct/S
 TODO
 tuple
 v1
+v2
 Versioning
 zeroize

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -24,4 +24,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Spellcheck
+        run: cargo spellcheck check -m 1 2>/dev/null
+      - name: Run Spellcheck on CHANGELOG.md
         run: cargo spellcheck check -m 1 CHANGELOG.md 2>/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Updated `syn` to v2.
+
+### Deprecated
+- The `crate` attribute now takes a path instead of a path inside a string
+  literal.
+
 ## [1.1.0] - 2022-02-06
 ### Added
 - `incomparable` variant and item attribute for `PartialEq` and `PartialOrd`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Changed
 - Updated `syn` to v2.
 
@@ -13,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   literal.
 
 ## [1.1.0] - 2022-02-06
+
 ### Added
 - `incomparable` variant and item attribute for `PartialEq` and `PartialOrd`
   derives, yielding false on all comparisons but `!=`.
@@ -21,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No changes.
 
 ## [1.0.0-rc.3] - 2022-03-21
+
 ### Fixed
 - Support attribute evaluation, e.g. `#[cfg(..)]` on fields.
 
@@ -31,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   introduced: `Debug`, `EqHashOrd`, `Hash` and `Zeroize`.
 
 ## [1.0.0-rc.2] - 2022-01-25
+
 ### Added
 - Support [`ZeroizeOnDrop`](https://docs.rs/zeroize/1.5/zeroize/trait.ZeroizeOnDrop.html).
 
@@ -41,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking Change**: Remove support for `Zeroize(drop)`.
 
 ## [1.0.0-rc.1] - 2021-12-08
+
 ### Added
 - Initial release.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ zeroize-on-drop = ["zeroize"]
 [dependencies]
 proc-macro2 = { version = "1", default-features = false, features = ["proc-macro"] }
 quote = { version = "1", default-features = false }
-syn = { version = "1.0.56", default-features = false, features = [
+syn = { version = "2", default-features = false, features = [
 	"clone-impls",
 	"derive",
 	"extra-traits",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ struct Example1<T>(PhantomData<T>);
 If using a different package name, you must specify this:
 
 ```rust
-#[derive_where(crate = "derive_where_")]
+#[derive_where(crate = derive_where_)]
 #[derive_where(Clone, Debug)]
 struct Example<T>(PhantomData<T>);
 ```
@@ -209,7 +209,7 @@ that would break their invariants.
   is to avoid ambiguity between another method also called `zeroize`.
 
 ```rust
-#[derive_where(Zeroize(crate = "zeroize_"))]
+#[derive_where(Zeroize(crate = zeroize_))]
 struct Example(#[derive_where(Zeroize(fqs))] i32);
 
 impl Example {
@@ -242,7 +242,7 @@ and can be implemented without [`Zeroize`], otherwise it only implements
   crate in case of a re-export or rename.
 
 ```rust
-#[derive_where(ZeroizeOnDrop(crate = "zeroize_"))]
+#[derive_where(ZeroizeOnDrop(crate = zeroize_))]
 struct Example(i32);
 
 assert!(core::mem::needs_drop::<Example>());

--- a/src/attr/field.rs
+++ b/src/attr/field.rs
@@ -1,8 +1,8 @@
 //! Attribute parsing for fields.
 
-use syn::{punctuated::Punctuated, spanned::Spanned, Attribute, Meta, Result, Token};
+use syn::{spanned::Spanned, Attribute, Meta, Result};
 
-use crate::{DeriveWhere, Error, Skip, DERIVE_WHERE};
+use crate::{util::MetaListExt, DeriveWhere, Error, Skip, DERIVE_WHERE};
 #[cfg(feature = "zeroize")]
 use crate::{Trait, TraitImpl, ZeroizeFqs};
 
@@ -45,11 +45,7 @@ impl FieldAttr {
 		debug_assert!(meta.path().is_ident(DERIVE_WHERE));
 
 		if let Meta::List(list) = meta {
-			let nested = list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
-
-			if nested.is_empty() {
-				return Err(Error::empty(list.span()));
-			}
+			let nested = list.parse_non_empty_nested_metas()?;
 
 			for meta in &nested {
 				if meta.path().is_ident(Skip::SKIP) {

--- a/src/attr/skip.rs
+++ b/src/attr/skip.rs
@@ -2,9 +2,9 @@
 
 use std::default::Default;
 
-use syn::{punctuated::Punctuated, spanned::Spanned, Meta, Path, Result, Token};
+use syn::{spanned::Spanned, Meta, Path, Result};
 
-use crate::{DeriveWhere, Error, Trait};
+use crate::{util::MetaListExt, DeriveWhere, Error, Trait};
 
 /// Stores what [`Trait`]s to skip this field or variant for.
 #[cfg_attr(test, derive(Debug))]
@@ -78,13 +78,7 @@ impl Skip {
 				}
 			}
 			Meta::List(list) => {
-				let nested =
-					list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
-
-				// Don't allow an empty list.
-				if nested.is_empty() {
-					return Err(Error::option_empty(list.span()));
-				}
+				let nested = list.parse_non_empty_nested_metas()?;
 
 				// Get traits already set to be skipped.
 				let traits = match self {

--- a/src/attr/skip.rs
+++ b/src/attr/skip.rs
@@ -2,7 +2,7 @@
 
 use std::default::Default;
 
-use syn::{spanned::Spanned, Meta, NestedMeta, Path, Result};
+use syn::{punctuated::Punctuated, spanned::Spanned, Meta, Path, Result, Token};
 
 use crate::{DeriveWhere, Error, Trait};
 
@@ -78,8 +78,11 @@ impl Skip {
 				}
 			}
 			Meta::List(list) => {
+				let nested =
+					list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+
 				// Don't allow an empty list.
-				if list.nested.is_empty() {
+				if nested.is_empty() {
 					return Err(Error::option_empty(list.span()));
 				}
 
@@ -100,8 +103,8 @@ impl Skip {
 					Skip::Traits(traits) => traits,
 				};
 
-				for nested_meta in &list.nested {
-					if let NestedMeta::Meta(Meta::Path(path)) = nested_meta {
+				for nested_meta in &nested {
+					if let Meta::Path(path) = nested_meta {
 						let skip_group = SkipGroup::from_path(path)?;
 
 						// Don't allow to skip the same trait twice.

--- a/src/attr/variant.rs
+++ b/src/attr/variant.rs
@@ -1,10 +1,8 @@
 //! Attribute parsing for variants.
 
-use syn::{
-	punctuated::Punctuated, spanned::Spanned, Attribute, Fields, Meta, Result, Token, Variant,
-};
+use syn::{spanned::Spanned, Attribute, Fields, Meta, Result, Variant};
 
-use crate::{Default, DeriveWhere, Error, Incomparable, Skip, DERIVE_WHERE};
+use crate::{util::MetaListExt, Default, DeriveWhere, Error, Incomparable, Skip, DERIVE_WHERE};
 
 /// Attributes on variant.
 #[derive(Default)]
@@ -46,7 +44,7 @@ impl VariantAttr {
 		debug_assert!(meta.path().is_ident(DERIVE_WHERE));
 
 		if let Meta::List(list) = meta {
-			let nested = list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+			let nested = list.parse_non_empty_nested_metas()?;
 
 			if nested.is_empty() {
 				return Err(Error::empty(list.span()));

--- a/src/attr/zeroize_fqs.rs
+++ b/src/attr/zeroize_fqs.rs
@@ -1,8 +1,8 @@
 //! Attribute parsing for the `Zeroize(fqs)` option.
 
-use syn::{punctuated::Punctuated, spanned::Spanned, Meta, Result, Token};
+use syn::{spanned::Spanned, Meta, Result};
 
-use crate::{DeriveWhere, Error, Trait, TraitImpl};
+use crate::{util::MetaListExt, DeriveWhere, Error, Trait, TraitImpl};
 
 /// Stores if this field should use FQS to call [`Zeroize::zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize).
 #[derive(Default)]
@@ -26,12 +26,7 @@ impl ZeroizeFqs {
 
 		match meta {
 			Meta::List(list) => {
-				let nested =
-					list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
-
-				if nested.is_empty() {
-					return Err(Error::option_empty(list.span()));
-				}
+				let nested = list.parse_non_empty_nested_metas()?;
 
 				for meta in &nested {
 					if let Meta::Path(path) = meta {

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,14 +73,6 @@ impl Error {
 		)
 	}
 
-	/// Invalid syntax for attribute.
-	pub fn attribute_syntax(span: Span, parse_error: syn::Error) -> syn::Error {
-		syn::Error::new(
-			span,
-			format!("unexpected attribute syntax, {}", parse_error),
-		)
-	}
-
 	/// Unsupported option in attribute.
 	#[cfg(feature = "zeroize")]
 	pub fn option_trait(span: Span, attribute: &str) -> syn::Error {

--- a/src/input.rs
+++ b/src/input.rs
@@ -174,7 +174,7 @@ impl<'a> Input<'a> {
 
 				#[cfg(feature = "zeroize")]
 				{
-					// `Zeroize(crate = "..")` or `ZeroizeOnDrop(crate = "..")` is used.
+					// `Zeroize(crate = ..)` or `ZeroizeOnDrop(crate = ..)` is used.
 					if let DeriveTrait::Zeroize { crate_: Some(_) }
 					| DeriveTrait::ZeroizeOnDrop { crate_: Some(_) } = *trait_
 					{

--- a/src/test/use_case.rs
+++ b/src/test/use_case.rs
@@ -131,7 +131,7 @@ fn default() -> Result<()> {
 #[cfg(feature = "zeroize")]
 fn zeroize_crate() -> Result<()> {
 	compiles(quote! {
-		#[derive_where(Zeroize(crate = "zeroize_"))]
+		#[derive_where(Zeroize(crate = zeroize_))]
 		struct Test(u8);
 	})
 }

--- a/src/test/zeroize.rs
+++ b/src/test/zeroize.rs
@@ -133,7 +133,7 @@ fn both() -> Result<()> {
 fn crate_() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Zeroize(crate = "zeroize_"); T)]
+			#[derive_where(Zeroize(crate = zeroize_); T)]
 			struct Test<T>(T);
 		},
 		quote! {
@@ -158,7 +158,7 @@ fn crate_() -> Result<()> {
 fn crate_drop() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(ZeroizeOnDrop(crate = "zeroize_"); T)]
+			#[derive_where(ZeroizeOnDrop(crate = zeroize_); T)]
 			struct Test<T>(T);
 		},
 		#[cfg(not(feature = "zeroize-on-drop"))]

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -15,8 +15,8 @@ mod zeroize;
 #[cfg(feature = "zeroize")]
 mod zeroize_on_drop;
 
-use proc_macro2::TokenStream;
-use syn::{spanned::Spanned, MetaList, Path, Result, TypeParamBound};
+use proc_macro2::{Span, TokenStream};
+use syn::{punctuated::Punctuated, spanned::Spanned, Meta, Path, Result, Token, TypeParamBound};
 
 use crate::{Data, DeriveTrait, Error, Item};
 
@@ -107,8 +107,12 @@ impl TraitImpl for Trait {
 		self.implementation().default_derive_trait()
 	}
 
-	fn parse_derive_trait(&self, list: MetaList) -> Result<DeriveTrait> {
-		self.implementation().parse_derive_trait(list)
+	fn parse_derive_trait(
+		&self,
+		span: Span,
+		list: Punctuated<Meta, Token![,]>,
+	) -> Result<DeriveTrait> {
+		self.implementation().parse_derive_trait(span, list)
 	}
 
 	fn supports_union(&self) -> bool {
@@ -154,8 +158,12 @@ pub trait TraitImpl {
 	fn default_derive_trait(&self) -> DeriveTrait;
 
 	/// Parse a `derive_where` trait with it's options.
-	fn parse_derive_trait(&self, list: MetaList) -> Result<DeriveTrait> {
-		Err(Error::options(list.span(), self.as_str()))
+	fn parse_derive_trait(
+		&self,
+		span: Span,
+		_list: Punctuated<Meta, Token![,]>,
+	) -> Result<DeriveTrait> {
+		Err(Error::options(span, self.as_str()))
 	}
 
 	/// Returns `true` if [`Trait`] supports unions.

--- a/src/trait_/zeroize.rs
+++ b/src/trait_/zeroize.rs
@@ -1,8 +1,10 @@
 //! [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) implementation.
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{spanned::Spanned, Lit, Meta, MetaList, NestedMeta, Path, Result};
+use syn::{
+	punctuated::Punctuated, spanned::Spanned, Expr, ExprLit, Lit, Meta, Path, Result, Token,
+};
 
 use crate::{util, Data, DeriveTrait, Error, Item, SimpleType, TraitImpl};
 
@@ -18,26 +20,34 @@ impl TraitImpl for Zeroize {
 		DeriveTrait::Zeroize { crate_: None }
 	}
 
-	fn parse_derive_trait(&self, list: MetaList) -> Result<DeriveTrait> {
+	fn parse_derive_trait(
+		&self,
+		_span: Span,
+		list: Punctuated<Meta, Token![,]>,
+	) -> Result<DeriveTrait> {
 		// This is already checked in `DeriveTrait::from_stream`.
-		debug_assert!(!list.nested.is_empty());
+		debug_assert!(!list.is_empty());
 
 		let mut crate_ = None;
 
-		for nested_meta in list.nested {
-			match &nested_meta {
-				NestedMeta::Meta(Meta::Path(path)) => {
+		for meta in list {
+			match &meta {
+				Meta::Path(path) => {
 					if path.is_ident("drop") {
 						return Err(Error::deprecated_zeroize_drop(path.span()));
 					} else {
 						return Err(Error::option_trait(path.span(), self.as_str()));
 					}
 				}
-				NestedMeta::Meta(Meta::NameValue(name_value)) => {
+				Meta::NameValue(name_value) => {
 					if name_value.path.is_ident("crate") {
 						// Check for duplicate `crate` option.
 						if crate_.is_none() {
-							if let Lit::Str(lit_str) = &name_value.lit {
+							if let Expr::Lit(ExprLit {
+								lit: Lit::Str(lit_str),
+								..
+							}) = &name_value.value
+							{
 								match lit_str.parse::<Path>() {
 									Ok(path) => {
 										if path == util::path_from_strs(&["zeroize"]) {
@@ -52,7 +62,7 @@ impl TraitImpl for Zeroize {
 									Err(error) => return Err(Error::path(lit_str.span(), error)),
 								}
 							} else {
-								return Err(Error::option_syntax(name_value.lit.span()));
+								return Err(Error::option_syntax(name_value.value.span()));
 							}
 						} else {
 							return Err(Error::option_duplicate(name_value.span(), "crate"));
@@ -62,7 +72,7 @@ impl TraitImpl for Zeroize {
 					}
 				}
 				_ => {
-					return Err(Error::option_syntax(nested_meta.span()));
+					return Err(Error::option_syntax(meta.span()));
 				}
 			}
 		}

--- a/src/trait_/zeroize.rs
+++ b/src/trait_/zeroize.rs
@@ -3,7 +3,8 @@
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
-	punctuated::Punctuated, spanned::Spanned, Expr, ExprLit, Lit, Meta, Path, Result, Token,
+	punctuated::Punctuated, spanned::Spanned, Expr, ExprLit, ExprPath, Lit, Meta, Path, Result,
+	Token,
 };
 
 use crate::{util, Data, DeriveTrait, Error, Item, SimpleType, TraitImpl};
@@ -43,27 +44,23 @@ impl TraitImpl for Zeroize {
 					if name_value.path.is_ident("crate") {
 						// Check for duplicate `crate` option.
 						if crate_.is_none() {
-							if let Expr::Lit(ExprLit {
-								lit: Lit::Str(lit_str),
-								..
-							}) = &name_value.value
-							{
-								match lit_str.parse::<Path>() {
-									Ok(path) => {
-										if path == util::path_from_strs(&["zeroize"]) {
-											return Err(Error::path_unnecessary(
-												path.span(),
-												"::zeroize",
-											));
-										}
-
-										crate_ = Some(path);
-									}
+							let path = match &name_value.value {
+								Expr::Lit(ExprLit {
+									lit: Lit::Str(lit_str),
+									..
+								}) => match lit_str.parse::<Path>() {
+									Ok(path) => path,
 									Err(error) => return Err(Error::path(lit_str.span(), error)),
-								}
-							} else {
-								return Err(Error::option_syntax(name_value.value.span()));
+								},
+								Expr::Path(ExprPath { path, .. }) => path.clone(),
+								_ => return Err(Error::option_syntax(name_value.value.span())),
+							};
+
+							if path == util::path_from_strs(&["zeroize"]) {
+								return Err(Error::path_unnecessary(path.span(), "::zeroize"));
 							}
+
+							crate_ = Some(path);
 						} else {
 							return Err(Error::option_duplicate(name_value.span(), "crate"));
 						}

--- a/test-crates/crate_/src/lib.rs
+++ b/test-crates/crate_/src/lib.rs
@@ -5,6 +5,11 @@ use core::marker::PhantomData;
 use derive_where_::derive_where;
 
 #[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "zeroize", derive_where(Zeroize(crate = zeroize_)))]
+#[derive_where(crate = derive_where_)]
+pub struct Test<T>(PhantomData<T>);
+
+#[derive_where(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "zeroize", derive_where(Zeroize(crate = "zeroize_")))]
 #[derive_where(crate = "derive_where_")]
-pub struct Test<T>(PhantomData<T>);
+pub struct TestDeprecated<T>(PhantomData<T>);

--- a/tests/ui/item.rs
+++ b/tests/ui/item.rs
@@ -32,6 +32,9 @@ struct OnlyCrate<T>(PhantomData<T>);
 #[derive_where(crate = "::derive_where")]
 struct DefaultCrate<T>(PhantomData<T>);
 
+#[derive_where(Debug = invalid; T)]
+struct WrongOptionSyntax<T, U>(T, PhantomData<U>);
+
 #[derive_where(Clone; T;)]
 struct SemiColonAtTheEnd<T, U>(T, PhantomData<U>);
 
@@ -46,9 +49,6 @@ struct MissingCommaBetweenTraits<T>(PhantomData<T>);
 
 #[derive_where(Clone; T U)]
 struct MissingCommaBetweenGenerics<T, U, V>(T, PhantomData<(U, V)>);
-
-#[derive_where("Clone")]
-struct InvalidTrait<T>(PhantomData<T>);
 
 #[derive_where(Clone)]
 #[derive_where::derive_where(Copy)]

--- a/tests/ui/item.rs
+++ b/tests/ui/item.rs
@@ -14,22 +14,22 @@ struct EmptyAttribute<T>(PhantomData<T>);
 struct WrongCrateSyntax<T>(PhantomData<T>);
 
 #[derive_where(crate = "struct Test")]
-struct InvalidPath<T>(PhantomData<T>);
+struct InvalidPathDeprecated<T>(PhantomData<T>);
 
-// The error message here shows that `crate = ".."` should be in it's own
+// The error message here shows that `crate = ..` should be in it's own
 // attribute instead of an error pointing out this is duplicate. This is not
 // ideal but much less complicated to implement.
-#[derive_where(crate = "derive_where_", crate = "derive_where_")]
+#[derive_where(crate = derive_where_, crate = derive_where_)]
 struct DuplicateCrate1<T>(PhantomData<T>);
 
-#[derive_where(crate = "derive_where_")]
-#[derive_where(crate = "derive_where_")]
+#[derive_where(crate = derive_where_)]
+#[derive_where(crate = derive_where_)]
 struct DuplicateCrate2<T>(PhantomData<T>);
 
-#[derive_where(crate = "derive_where_")]
+#[derive_where(crate = derive_where_)]
 struct OnlyCrate<T>(PhantomData<T>);
 
-#[derive_where(crate = "::derive_where")]
+#[derive_where(crate = ::derive_where)]
 struct DefaultCrate<T>(PhantomData<T>);
 
 #[derive_where(Debug = invalid; T)]

--- a/tests/ui/item.stderr
+++ b/tests/ui/item.stderr
@@ -50,41 +50,41 @@ error: unnecessary path qualification, `::derive_where` is used by default
 32 | #[derive_where(crate = "::derive_where")]
    |                        ^^^^^^^^^^^^^^^^
 
-error: expected `,`
-  --> tests/ui/item.rs:35:24
+error: unexpected option syntax
+  --> tests/ui/item.rs:35:16
    |
-35 | #[derive_where(Clone; T;)]
+35 | #[derive_where(Debug = invalid; T)]
+   |                ^^^^^^^^^^^^^^^
+
+error: expected `,`
+  --> tests/ui/item.rs:38:24
+   |
+38 | #[derive_where(Clone; T;)]
    |                        ^
 
-error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:38:25
+error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, `dyn`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
+  --> tests/ui/item.rs:41:25
    |
-38 | #[derive_where(Clone; T,,)]
+41 | #[derive_where(Clone; T,,)]
    |                         ^
 
-error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/ui/item.rs:41:23
+error: expected type to bind to, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, `dyn`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
+  --> tests/ui/item.rs:44:23
    |
-41 | #[derive_where(Clone; where)]
+44 | #[derive_where(Clone; where)]
    |                       ^^^^^
 
 error: expected `;` or `,
-  --> tests/ui/item.rs:44:22
+  --> tests/ui/item.rs:47:22
    |
-44 | #[derive_where(Clone Debug)]
+47 | #[derive_where(Clone Debug)]
    |                      ^^^^^
 
 error: expected `,`
-  --> tests/ui/item.rs:47:25
+  --> tests/ui/item.rs:50:25
    |
-47 | #[derive_where(Clone; T U)]
+50 | #[derive_where(Clone; T U)]
    |                         ^
-
-error: unexpected option syntax
-  --> tests/ui/item.rs:50:16
-   |
-50 | #[derive_where("Clone")]
-   |                ^^^^^^^
 
 error: `#[derive_where(..)` was already applied to this item before, this occurs when using a qualified path for any `#[derive_where(..)`s except the first
   --> tests/ui/item.rs:53:1

--- a/tests/ui/item.stderr
+++ b/tests/ui/item.stderr
@@ -29,14 +29,14 @@ error: expected path, expected identifier
 error: the `crate` option has to be defined in it's own `#[derive_where(..)` attribute
   --> tests/ui/item.rs:22:16
    |
-22 | #[derive_where(crate = "derive_where_", crate = "derive_where_")]
+22 | #[derive_where(crate = derive_where_, crate = derive_where_)]
    |                ^^^^^
 
 error: duplicate `crate` option
   --> tests/ui/item.rs:26:16
    |
-26 | #[derive_where(crate = "derive_where_")]
-   |                ^^^^^^^^^^^^^^^^^^^^^^^
+26 | #[derive_where(crate = derive_where_)]
+   |                ^^^^^^^^^^^^^^^^^^^^^
 
 error: no traits found to implement, use `#[derive_where(..)` to specify some
   --> tests/ui/item.rs:30:1
@@ -47,8 +47,8 @@ error: no traits found to implement, use `#[derive_where(..)` to specify some
 error: unnecessary path qualification, `::derive_where` is used by default
   --> tests/ui/item.rs:32:24
    |
-32 | #[derive_where(crate = "::derive_where")]
-   |                        ^^^^^^^^^^^^^^^^
+32 | #[derive_where(crate = ::derive_where)]
+   |                        ^^^^^^^^^^^^^^
 
 error: unexpected option syntax
   --> tests/ui/item.rs:35:16

--- a/tests/ui/item_option_syntax.rs
+++ b/tests/ui/item_option_syntax.rs
@@ -2,9 +2,6 @@ use std::marker::PhantomData;
 
 use derive_where::derive_where;
 
-#[derive_where = "invalid"]
-struct WrongAttributeSyntax<T>(PhantomData<T>);
-
 #[derive_where()]
 struct EmptyAttribute<T>(PhantomData<T>);
 

--- a/tests/ui/item_option_syntax.stderr
+++ b/tests/ui/item_option_syntax.stderr
@@ -1,37 +1,25 @@
-error: key-value macro attributes are not supported
+error: empty `derive_where` found
  --> tests/ui/item_option_syntax.rs:5:1
   |
-5 | #[derive_where = "invalid"]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: unexpected option syntax
- --> tests/ui/item_option_syntax.rs:5:18
-  |
-5 | #[derive_where = "invalid"]
-  |                  ^^^^^^^^^
-
-error: empty `derive_where` found
- --> tests/ui/item_option_syntax.rs:8:1
-  |
-8 | #[derive_where()]
+5 | #[derive_where()]
   | ^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected option syntax
-  --> tests/ui/item_option_syntax.rs:11:16
-   |
-11 | #[derive_where(Debug = "option")]
-   |                ^^^^^^^^^^^^^^^^
+ --> tests/ui/item_option_syntax.rs:8:16
+  |
+8 | #[derive_where(Debug = "option")]
+  |                ^^^^^^^^^^^^^^^^
 
 error: empty attribute option found
-  --> tests/ui/item_option_syntax.rs:14:16
+  --> tests/ui/item_option_syntax.rs:11:16
    |
-14 | #[derive_where(Debug())]
+11 | #[derive_where(Debug())]
    |                ^^^^^^^
 
 error: `Debug` doesn't support any options
-  --> tests/ui/item_option_syntax.rs:17:16
+  --> tests/ui/item_option_syntax.rs:14:16
    |
-17 | #[derive_where(Debug(option))]
+14 | #[derive_where(Debug(option))]
    |                ^^^^^^^^^^^^^

--- a/tests/ui/not-zeroize/item.rs
+++ b/tests/ui/not-zeroize/item.rs
@@ -5,9 +5,6 @@ use derive_where::derive_where;
 #[derive_where(skip_inner, Clone)]
 struct SkipInnerWithTrait<T>(PhantomData<T>);
 
-#[derive_where(Debug = invalid; T)]
-struct WrongOptionSyntax<T, U>(T, PhantomData<U>);
-
 #[derive_where(,)]
 struct OnlyComma<T>(PhantomData<T>);
 
@@ -16,6 +13,9 @@ struct StartWithComma<T>(PhantomData<T>);
 
 #[derive_where(Clone,,)]
 struct DuplicateCommaAtEnd<T>(PhantomData<T>);
+
+#[derive_where("Clone")]
+struct InvalidTrait<T>(PhantomData<T>);
 
 #[derive_where(T)]
 struct GenericInsteadTrait<T, U>(T, PhantomData<U>);

--- a/tests/ui/not-zeroize/item.rs
+++ b/tests/ui/not-zeroize/item.rs
@@ -2,6 +2,9 @@ use std::marker::PhantomData;
 
 use derive_where::derive_where;
 
+#[derive_where(crate = struct Test)]
+struct InvalidPath<T>(PhantomData<T>);
+
 #[derive_where(skip_inner, Clone)]
 struct SkipInnerWithTrait<T>(PhantomData<T>);
 

--- a/tests/ui/not-zeroize/item.stderr
+++ b/tests/ui/not-zeroize/item.stderr
@@ -1,35 +1,41 @@
-error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
- --> tests/ui/not-zeroize/item.rs:5:16
-  |
-5 | #[derive_where(skip_inner, Clone)]
-  |                ^^^^^^^^^^
-
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+ --> tests/ui/not-zeroize/item.rs:5:24
+  |
+5 | #[derive_where(crate = struct Test)]
+  |                        ^^^^^^
+
+error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
  --> tests/ui/not-zeroize/item.rs:8:16
   |
-8 | #[derive_where(,)]
-  |                ^
+8 | #[derive_where(skip_inner, Clone)]
+  |                ^^^^^^^^^^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
   --> tests/ui/not-zeroize/item.rs:11:16
    |
-11 | #[derive_where(,Clone)]
+11 | #[derive_where(,)]
    |                ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
-  --> tests/ui/not-zeroize/item.rs:14:22
+  --> tests/ui/not-zeroize/item.rs:14:16
    |
-14 | #[derive_where(Clone,,)]
+14 | #[derive_where(,Clone)]
+   |                ^
+
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+  --> tests/ui/not-zeroize/item.rs:17:22
+   |
+17 | #[derive_where(Clone,,)]
    |                      ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
-  --> tests/ui/not-zeroize/item.rs:17:16
+  --> tests/ui/not-zeroize/item.rs:20:16
    |
-17 | #[derive_where("Clone")]
+20 | #[derive_where("Clone")]
    |                ^^^^^^^
 
 error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
-  --> tests/ui/not-zeroize/item.rs:20:16
+  --> tests/ui/not-zeroize/item.rs:23:16
    |
-20 | #[derive_where(T)]
+23 | #[derive_where(T)]
    |                ^

--- a/tests/ui/not-zeroize/item.stderr
+++ b/tests/ui/not-zeroize/item.stderr
@@ -5,28 +5,28 @@ error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash,
   |                ^^^^^^^^^^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
- --> tests/ui/not-zeroize/item.rs:8:24
+ --> tests/ui/not-zeroize/item.rs:8:16
   |
-8 | #[derive_where(Debug = invalid; T)]
-  |                        ^^^^^^^
+8 | #[derive_where(,)]
+  |                ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
   --> tests/ui/not-zeroize/item.rs:11:16
    |
-11 | #[derive_where(,)]
+11 | #[derive_where(,Clone)]
    |                ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
-  --> tests/ui/not-zeroize/item.rs:14:16
+  --> tests/ui/not-zeroize/item.rs:14:22
    |
-14 | #[derive_where(,Clone)]
-   |                ^
-
-error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
-  --> tests/ui/not-zeroize/item.rs:17:22
-   |
-17 | #[derive_where(Clone,,)]
+14 | #[derive_where(Clone,,)]
    |                      ^
+
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+  --> tests/ui/not-zeroize/item.rs:17:16
+   |
+17 | #[derive_where("Clone")]
+   |                ^^^^^^^
 
 error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
   --> tests/ui/not-zeroize/item.rs:20:16

--- a/tests/ui/not-zeroize/item_option_syntax.rs
+++ b/tests/ui/not-zeroize/item_option_syntax.rs
@@ -4,3 +4,5 @@ use derive_where::derive_where;
 
 #[derive_where = "invalid"]
 struct WrongAttributeSyntax<T>(PhantomData<T>);
+
+fn main() {}

--- a/tests/ui/not-zeroize/item_option_syntax.rs
+++ b/tests/ui/not-zeroize/item_option_syntax.rs
@@ -1,0 +1,6 @@
+use std::marker::PhantomData;
+
+use derive_where::derive_where;
+
+#[derive_where = "invalid"]
+struct WrongAttributeSyntax<T>(PhantomData<T>);

--- a/tests/ui/not-zeroize/item_option_syntax.stderr
+++ b/tests/ui/not-zeroize/item_option_syntax.stderr
@@ -1,0 +1,17 @@
+error: key-value macro attributes are not supported
+ --> tests/ui/not-zeroize/item_option_syntax.rs:5:1
+  |
+5 | #[derive_where = "invalid"]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd
+ --> tests/ui/not-zeroize/item_option_syntax.rs:5:18
+  |
+5 | #[derive_where = "invalid"]
+  |                  ^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/not-zeroize/item_option_syntax.rs:6:48
+  |
+6 | struct WrongAttributeSyntax<T>(PhantomData<T>);
+  |                                                ^ consider adding a `main` function to `$DIR/tests/ui/not-zeroize/item_option_syntax.rs`

--- a/tests/ui/not-zeroize/item_option_syntax.stderr
+++ b/tests/ui/not-zeroize/item_option_syntax.stderr
@@ -9,9 +9,3 @@ error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq
   |
 5 | #[derive_where = "invalid"]
   |                  ^^^^^^^^^
-
-error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui/not-zeroize/item_option_syntax.rs:6:48
-  |
-6 | struct WrongAttributeSyntax<T>(PhantomData<T>);
-  |                                                ^ consider adding a `main` function to `$DIR/tests/ui/not-zeroize/item_option_syntax.rs`

--- a/tests/ui/zeroize/item.rs
+++ b/tests/ui/zeroize/item.rs
@@ -5,9 +5,6 @@ use derive_where::derive_where;
 #[derive_where(skip_inner, Clone)]
 struct SkipInnerWithTrait<T>(PhantomData<T>);
 
-#[derive_where(Debug = invalid; T)]
-struct WrongOptionSyntax<T, U>(T, PhantomData<U>);
-
 #[derive_where(,)]
 struct OnlyComma<T>(PhantomData<T>);
 
@@ -16,6 +13,9 @@ struct StartWithComma<T>(PhantomData<T>);
 
 #[derive_where(Clone,,)]
 struct DuplicateCommaAtEnd<T>(PhantomData<T>);
+
+#[derive_where("Clone")]
+struct InvalidTrait<T>(PhantomData<T>);
 
 #[derive_where(T)]
 struct GenericInsteadTrait<T, U>(T, PhantomData<U>);

--- a/tests/ui/zeroize/item.rs
+++ b/tests/ui/zeroize/item.rs
@@ -2,6 +2,9 @@ use std::marker::PhantomData;
 
 use derive_where::derive_where;
 
+#[derive_where(crate = struct Test)]
+struct InvalidPath<T>(PhantomData<T>);
+
 #[derive_where(skip_inner, Clone)]
 struct SkipInnerWithTrait<T>(PhantomData<T>);
 

--- a/tests/ui/zeroize/item.stderr
+++ b/tests/ui/zeroize/item.stderr
@@ -5,28 +5,28 @@ error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash,
   |                ^^^^^^^^^^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
- --> tests/ui/zeroize/item.rs:8:24
+ --> tests/ui/zeroize/item.rs:8:16
   |
-8 | #[derive_where(Debug = invalid; T)]
-  |                        ^^^^^^^
+8 | #[derive_where(,)]
+  |                ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:11:16
    |
-11 | #[derive_where(,)]
+11 | #[derive_where(,Clone)]
    |                ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
-  --> tests/ui/zeroize/item.rs:14:16
+  --> tests/ui/zeroize/item.rs:14:22
    |
-14 | #[derive_where(,Clone)]
-   |                ^
-
-error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
-  --> tests/ui/zeroize/item.rs:17:22
-   |
-17 | #[derive_where(Clone,,)]
+14 | #[derive_where(Clone,,)]
    |                      ^
+
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+  --> tests/ui/zeroize/item.rs:17:16
+   |
+17 | #[derive_where("Clone")]
+   |                ^^^^^^^
 
 error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:20:16

--- a/tests/ui/zeroize/item.stderr
+++ b/tests/ui/zeroize/item.stderr
@@ -1,35 +1,41 @@
-error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
- --> tests/ui/zeroize/item.rs:5:16
-  |
-5 | #[derive_where(skip_inner, Clone)]
-  |                ^^^^^^^^^^
-
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+ --> tests/ui/zeroize/item.rs:5:24
+  |
+5 | #[derive_where(crate = struct Test)]
+  |                        ^^^^^^
+
+error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
  --> tests/ui/zeroize/item.rs:8:16
   |
-8 | #[derive_where(,)]
-  |                ^
+8 | #[derive_where(skip_inner, Clone)]
+  |                ^^^^^^^^^^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
   --> tests/ui/zeroize/item.rs:11:16
    |
-11 | #[derive_where(,Clone)]
+11 | #[derive_where(,)]
    |                ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
-  --> tests/ui/zeroize/item.rs:14:22
+  --> tests/ui/zeroize/item.rs:14:16
    |
-14 | #[derive_where(Clone,,)]
+14 | #[derive_where(,Clone)]
+   |                ^
+
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+  --> tests/ui/zeroize/item.rs:17:22
+   |
+17 | #[derive_where(Clone,,)]
    |                      ^
 
 error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
-  --> tests/ui/zeroize/item.rs:17:16
+  --> tests/ui/zeroize/item.rs:20:16
    |
-17 | #[derive_where("Clone")]
+20 | #[derive_where("Clone")]
    |                ^^^^^^^
 
 error: unsupported trait, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
-  --> tests/ui/zeroize/item.rs:20:16
+  --> tests/ui/zeroize/item.rs:23:16
    |
-20 | #[derive_where(T)]
+23 | #[derive_where(T)]
    |                ^

--- a/tests/ui/zeroize/item_option_syntax.rs
+++ b/tests/ui/zeroize/item_option_syntax.rs
@@ -4,3 +4,5 @@ use derive_where::derive_where;
 
 #[derive_where = "invalid"]
 struct WrongAttributeSyntax<T>(PhantomData<T>);
+
+fn main() {}

--- a/tests/ui/zeroize/item_option_syntax.rs
+++ b/tests/ui/zeroize/item_option_syntax.rs
@@ -1,0 +1,6 @@
+use std::marker::PhantomData;
+
+use derive_where::derive_where;
+
+#[derive_where = "invalid"]
+struct WrongAttributeSyntax<T>(PhantomData<T>);

--- a/tests/ui/zeroize/item_option_syntax.stderr
+++ b/tests/ui/zeroize/item_option_syntax.stderr
@@ -1,0 +1,17 @@
+error: key-value macro attributes are not supported
+ --> tests/ui/zeroize/item_option_syntax.rs:5:1
+  |
+5 | #[derive_where = "invalid"]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize, ZeroizeOnDrop
+ --> tests/ui/zeroize/item_option_syntax.rs:5:18
+  |
+5 | #[derive_where = "invalid"]
+  |                  ^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/zeroize/item_option_syntax.rs:6:48
+  |
+6 | struct WrongAttributeSyntax<T>(PhantomData<T>);
+  |                                                ^ consider adding a `main` function to `$DIR/tests/ui/zeroize/item_option_syntax.rs`

--- a/tests/ui/zeroize/item_option_syntax.stderr
+++ b/tests/ui/zeroize/item_option_syntax.stderr
@@ -9,9 +9,3 @@ error: unsupported trait syntax, expected one of Clone, Copy, Debug, Default, Eq
   |
 5 | #[derive_where = "invalid"]
   |                  ^^^^^^^^^
-
-error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui/zeroize/item_option_syntax.rs:6:48
-  |
-6 | struct WrongAttributeSyntax<T>(PhantomData<T>);
-  |                                                ^ consider adding a `main` function to `$DIR/tests/ui/zeroize/item_option_syntax.rs`

--- a/tests/ui/zeroize/use_case.rs
+++ b/tests/ui/zeroize/use_case.rs
@@ -2,7 +2,7 @@ extern crate zeroize_ as zeroize;
 
 use derive_where::derive_where;
 
-#[derive_where(Clone, Zeroize(crate = "zeroize_"); T)]
+#[derive_where(Clone, Zeroize(crate = zeroize_); T)]
 struct ZeroizeCrate<T>(T);
 
 #[derive_where(Clone, Zeroize; T)]

--- a/tests/ui/zeroize/use_case.stderr
+++ b/tests/ui/zeroize/use_case.stderr
@@ -1,7 +1,7 @@
 error: this can be handled by standard `#[derive(..)]`, use a `skip` or `incomparable` attribute, implement `Default` on an enum, or different generic type parameters
  --> tests/ui/zeroize/use_case.rs:5:16
   |
-5 | #[derive_where(Clone, Zeroize(crate = "zeroize_"); T)]
+5 | #[derive_where(Clone, Zeroize(crate = zeroize_); T)]
   |                ^^^^^
 
 error: this can be handled by standard `#[derive(..)]`, use a `skip` or `incomparable` attribute, implement `Default` on an enum, or different generic type parameters

--- a/tests/ui/zeroize/zeroize.rs
+++ b/tests/ui/zeroize/zeroize.rs
@@ -16,13 +16,16 @@ struct WrongOptionSyntax2<T>(PhantomData<T>);
 #[derive_where(Zeroize(crate(zeroize_)))]
 struct WrongCrateSyntax<T>(PhantomData<T>);
 
-#[derive_where(Zeroize(crate = "struct Test"))]
+#[derive_where(Zeroize(crate = struct Test))]
 struct InvalidPath<T>(PhantomData<T>);
 
-#[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_"))]
+#[derive_where(Zeroize(crate = "struct Test"))]
+struct InvalidPathDeprecated<T>(PhantomData<T>);
+
+#[derive_where(Zeroize(crate = zeroize_, crate = zeroize_))]
 struct DuplicateCrate<T>(PhantomData<T>);
 
-#[derive_where(Zeroize(crate = "::zeroize"))]
+#[derive_where(Zeroize(crate = ::zeroize))]
 struct DefaultCrate<T>(PhantomData<T>);
 
 fn main() {}

--- a/tests/ui/zeroize/zeroize.stderr
+++ b/tests/ui/zeroize/zeroize.stderr
@@ -10,7 +10,7 @@ error: `Zeroize` doesn't support this option
 10 | #[derive_where(Zeroize(test = "test"))]
    |                        ^^^^
 
-error: unexpected option syntax
+error: expected path
   --> tests/ui/zeroize/zeroize.rs:13:24
    |
 13 | #[derive_where(Zeroize("option"))]

--- a/tests/ui/zeroize/zeroize.stderr
+++ b/tests/ui/zeroize/zeroize.stderr
@@ -22,20 +22,26 @@ error: unexpected option syntax
 16 | #[derive_where(Zeroize(crate(zeroize_)))]
    |                        ^^^^^^^^^^^^^^^
 
-error: expected path, expected identifier
+error: expected expression
   --> tests/ui/zeroize/zeroize.rs:19:32
    |
-19 | #[derive_where(Zeroize(crate = "struct Test"))]
+19 | #[derive_where(Zeroize(crate = struct Test))]
+   |                                ^^^^^^
+
+error: expected path, expected identifier
+  --> tests/ui/zeroize/zeroize.rs:22:32
+   |
+22 | #[derive_where(Zeroize(crate = "struct Test"))]
    |                                ^^^^^^^^^^^^^
 
 error: duplicate `crate` option
-  --> tests/ui/zeroize/zeroize.rs:22:44
+  --> tests/ui/zeroize/zeroize.rs:25:42
    |
-22 | #[derive_where(Zeroize(crate = "zeroize_", crate = "zeroize_"))]
-   |                                            ^^^^^^^^^^^^^^^^^^
+25 | #[derive_where(Zeroize(crate = zeroize_, crate = zeroize_))]
+   |                                          ^^^^^^^^^^^^^^^^
 
 error: unnecessary path qualification, `::zeroize` is used by default
-  --> tests/ui/zeroize/zeroize.rs:25:32
+  --> tests/ui/zeroize/zeroize.rs:28:32
    |
-25 | #[derive_where(Zeroize(crate = "::zeroize"))]
-   |                                ^^^^^^^^^^^
+28 | #[derive_where(Zeroize(crate = ::zeroize))]
+   |                                ^^^^^^^^^

--- a/tests/zeroize.rs
+++ b/tests/zeroize.rs
@@ -35,7 +35,7 @@ fn basic() {
 
 #[test]
 fn crate_() {
-	#[derive_where(Zeroize(crate = "zeroize_"))]
+	#[derive_where(Zeroize(crate = zeroize_))]
 	struct Test<T>(Wrapper<T>);
 
 	let mut test = Test(42.into());


### PR DESCRIPTION
The big change here is that we have to parse `MetaList` on our own.

One thing I was concerned about was that the new `NestedMeta` used to support a free standing literal, but when you parse to `Meta` that's an error now. Luckily we didn't use it anywhere.

Some slightly improved error messages.

One thing I noticed we can improve now is that `MetaNameValue` now takes an `Expr` as a value, so now we can actually take a path instead of a string literal in the `crate` attribute.

Also noticed that our spellchecker wasn't running properly but only checking `CHANGELOG.md`.