### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,8 +104,6 @@ jobs:
             features: safe,zeroize-on-drop
           - version: stable
             features: safe,zeroize-on-drop
-          - version: nightly
-            features: nightly,safe,zeroize-on-drop
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,11 +12,12 @@ jobs:
   test:
     name: Test
 
+    if: github.event_name == 'schedule'
+
     strategy:
       fail-fast: false
       matrix:
         rust:
-          - 1.57.0
           - stable
           - beta
 
@@ -50,17 +51,6 @@ jobs:
         run: |
           rustup toolchain install nightly --profile minimal --component miri,rust-src --allow-downgrade
           rustup default nightly
-      - name: Cache xargo
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin/xargo
-            ~/.cargo/bin/xargo-check
-          key: xargo
-      - name: Install xargo
-        run: cargo install xargo
       - name: Checkout
         uses: actions/checkout@v3
       - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `PartialOrd` implementations now use `Ord` if applicable.
+
 ## [1.2.1] - 2022-04-14
 
 ### Fixed

--- a/src/attr/default.rs
+++ b/src/attr/default.rs
@@ -6,7 +6,7 @@ use syn::{spanned::Spanned, Meta, Result};
 use crate::{DeriveWhere, Error, Trait};
 
 /// Stores if this variant should be the default when implementing
-/// [`Default`](std::default::Default).
+/// [`Default`](trait@std::default::Default).
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(test, derive(Debug))]
 pub struct Default(pub Option<Span>);

--- a/src/attr/field.rs
+++ b/src/attr/field.rs
@@ -11,6 +11,7 @@ use crate::{Trait, TraitImpl, ZeroizeFqs};
 #[cfg_attr(test, derive(Debug))]
 pub struct FieldAttr {
 	/// [`Trait`](crate::Trait)s to skip this field for.
+	#[cfg_attr(feature = "zeroize", allow(rustdoc::redundant_explicit_links))]
 	pub skip: Skip,
 	/// Use fully-qualified-syntax for the [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) implementation on this field.
 	#[cfg(feature = "zeroize")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![deny(unsafe_code)]
-#![cfg_attr(feature = "nightly", feature(allow_internal_unstable))]
+#![cfg_attr(
+	feature = "nightly",
+	feature(allow_internal_unstable),
+	allow(internal_features)
+)]
 #![allow(clippy::tabs_in_doc_comments)]
 #![warn(clippy::cargo, clippy::missing_docs_in_private_items)]
 #![cfg_attr(doc, allow(unknown_lints), warn(rustdoc::all))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ const DERIVE_WHERE_VISITED: &str = "derive_where_visited";
 ///
 /// Variant-level options:
 /// - `#[derive_where(default)]`: Uses this variant as the default for the
-///   [`Default`](core::default::Default) implementation.
+///   [`Default`](trait@core::default::Default) implementation.
 /// - `#[derive_where(skip_inner(EqHashOrd, ..))]`: Skip all fields in this
 ///   variant. Optionally specify trait groups to constrain skipping fields.
 ///
@@ -448,7 +448,7 @@ const DERIVE_WHERE_VISITED: &str = "derive_where_visited";
 /// - `#[derive_where(Zeroize(fqs))]`: Use fully-qualified-syntax when
 ///   implementing [`Zeroize`].
 ///
-/// See the [crate](crate) level description for more details.
+/// See the [crate] level description for more details.
 ///
 /// [`Zeroize`]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
 /// [`ZeroizeOnDrop`]: https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -83,13 +83,7 @@ fn struct_() -> Result<()> {
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
-					match (self, __other) {
-						(Test { field: ref __field }, Test { field: ref __other_field }) =>
-							match ::core::cmp::PartialOrd::partial_cmp(__field, __other_field) {
-								::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
-								__cmp => __cmp,
-							},
-					}
+					::core::option::Option::Some(::core::cmp::Ord::cmp(self, __other))
 				}
 			}
 		},
@@ -176,13 +170,7 @@ fn tuple() -> Result<()> {
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
-					match (self, __other) {
-						(Test(ref __0), Test(ref __other_0)) =>
-							match ::core::cmp::PartialOrd::partial_cmp(__0, __other_0) {
-								::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
-								__cmp => __cmp,
-							},
-					}
+					::core::option::Option::Some(::core::cmp::Ord::cmp(self, __other))
 				}
 			}
 		},
@@ -233,39 +221,6 @@ fn enum_() -> Result<()> {
 					_ => ::core::cmp::Ordering::Less,
 				},
 			Test::E => ::core::cmp::Ordering::Greater,
-		}
-	};
-	#[cfg(feature = "nightly")]
-	let partial_ord = quote! {
-		::core::cmp::PartialOrd::partial_cmp(&__self_disc, &__other_disc)
-	};
-	#[cfg(not(any(feature = "nightly", feature = "safe")))]
-	let partial_ord = quote! {
-		::core::cmp::PartialOrd::partial_cmp(
-			&unsafe { ::core::mem::transmute::<_, isize>(__self_disc) },
-			&unsafe { ::core::mem::transmute::<_, isize>(__other_disc) },
-		)
-	};
-	#[cfg(all(not(feature = "nightly"), feature = "safe"))]
-	let partial_ord = quote! {
-		match self {
-			Test::A { field: ref __field } => ::core::option::Option::Some(::core::cmp::Ordering::Less),
-			Test::B { } =>
-				match __other {
-					Test::A { .. } => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
-					_ => ::core::option::Option::Some(::core::cmp::Ordering::Less),
-				},
-			Test::C(ref __0) =>
-				match __other {
-					Test::A { .. } | Test::B { .. } => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
-					_ => ::core::option::Option::Some(::core::cmp::Ordering::Less),
-				},
-			Test::D() =>
-				match __other {
-					Test::A { .. } | Test::B { .. } | Test::C(..) => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
-					_ => ::core::option::Option::Some(::core::cmp::Ordering::Less),
-				},
-			Test::E => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
 		}
 	};
 
@@ -404,25 +359,7 @@ fn enum_() -> Result<()> {
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
-					#discriminant
-
-					if __self_disc == __other_disc {
-						match (self, __other) {
-							(Test::A { field: ref __field }, Test::A { field: ref __other_field }) =>
-								match ::core::cmp::PartialOrd::partial_cmp(__field, __other_field) {
-									::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
-									__cmp => __cmp,
-								},
-							(Test::C(ref __0), Test::C(ref __other_0)) =>
-								match ::core::cmp::PartialOrd::partial_cmp(__0, __other_0) {
-									::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
-									__cmp => __cmp,
-								},
-							_ => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
-						}
-					} else {
-						#partial_ord
-					}
+					::core::option::Option::Some(::core::cmp::Ord::cmp(self, __other))
 				}
 			}
 		},

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -246,16 +246,7 @@ fn check_trait_bounds() -> Result<()> {
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
-					match (self, __other) {
-						(Test(ref __0, ref __1), Test(ref __other_0, ref __other_1)) =>
-							match ::core::cmp::PartialOrd::partial_cmp(__0, __other_0) {
-								::core::option::Option::Some(::core::cmp::Ordering::Equal) => match ::core::cmp::PartialOrd::partial_cmp(__1, __other_1) {
-									::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
-									__cmp => __cmp,
-								},
-								__cmp => __cmp,
-							},
-					}
+					::core::option::Option::Some(::core::cmp::Ord::cmp(self, __other))
 				}
 			}
 		},
@@ -387,16 +378,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 			{
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
-					match (self, __other) {
-						(Test(ref __0, ref __1), Test(ref __other_0, ref __other_1)) =>
-							match ::core::cmp::PartialOrd::partial_cmp(__0, __other_0) {
-								::core::option::Option::Some(::core::cmp::Ordering::Equal) => match ::core::cmp::PartialOrd::partial_cmp(__1, __other_1) {
-									::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
-									__cmp => __cmp,
-								},
-								__cmp => __cmp,
-							},
-					}
+					::core::option::Option::Some(::core::cmp::Ord::cmp(self, __other))
 				}
 			}
 		},

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -4,6 +4,7 @@ mod enum_;
 #[cfg(not(any(feature = "nightly", feature = "safe")))]
 mod incomparable;
 mod misc;
+mod partial_ord;
 mod skip;
 mod use_case;
 #[cfg(feature = "zeroize")]

--- a/src/test/partial_ord.rs
+++ b/src/test/partial_ord.rs
@@ -1,0 +1,208 @@
+use quote::quote;
+use syn::Result;
+
+use super::test_derive;
+
+#[test]
+fn struct_() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(PartialOrd)]
+			struct Test<T> { field: std::marker::PhatomData<T> }
+		},
+		quote! {
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
+				#[inline]
+				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+					match (self, __other) {
+						(Test { field: ref __field }, Test { field: ref __other_field }) =>
+							match ::core::cmp::PartialOrd::partial_cmp(__field, __other_field) {
+								::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
+								__cmp => __cmp,
+							},
+					}
+				}
+			}
+		},
+	)
+}
+
+#[test]
+fn tuple() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(PartialOrd)]
+			struct Test<T>(std::marker::PhatomData<T>);
+		},
+		quote! {
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
+				#[inline]
+				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+					match (self, __other) {
+						(Test(ref __0), Test(ref __other_0)) =>
+							match ::core::cmp::PartialOrd::partial_cmp(__0, __other_0) {
+								::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
+								__cmp => __cmp,
+							},
+					}
+				}
+			}
+		},
+	)
+}
+
+#[test]
+fn enum_() -> Result<()> {
+	#[cfg(feature = "nightly")]
+	let discriminant = quote! {
+		let __self_disc = ::core::intrinsics::discriminant_value(self);
+		let __other_disc = ::core::intrinsics::discriminant_value(__other);
+	};
+	#[cfg(not(feature = "nightly"))]
+	let discriminant = quote! {
+		let __self_disc = ::core::mem::discriminant(self);
+		let __other_disc = ::core::mem::discriminant(__other);
+	};
+	#[cfg(feature = "nightly")]
+	let partial_ord = quote! {
+		::core::cmp::PartialOrd::partial_cmp(&__self_disc, &__other_disc)
+	};
+	#[cfg(not(any(feature = "nightly", feature = "safe")))]
+	let partial_ord = quote! {
+		::core::cmp::PartialOrd::partial_cmp(
+			&unsafe { ::core::mem::transmute::<_, isize>(__self_disc) },
+			&unsafe { ::core::mem::transmute::<_, isize>(__other_disc) },
+		)
+	};
+	#[cfg(all(not(feature = "nightly"), feature = "safe"))]
+	let partial_ord = quote! {
+		match self {
+			Test::A { field: ref __field } => ::core::option::Option::Some(::core::cmp::Ordering::Less),
+			Test::B { } =>
+				match __other {
+					Test::A { .. } => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
+					_ => ::core::option::Option::Some(::core::cmp::Ordering::Less),
+				},
+			Test::C(ref __0) =>
+				match __other {
+					Test::A { .. } | Test::B { .. } => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
+					_ => ::core::option::Option::Some(::core::cmp::Ordering::Less),
+				},
+			Test::D() =>
+				match __other {
+					Test::A { .. } | Test::B { .. } | Test::C(..) => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
+					_ => ::core::option::Option::Some(::core::cmp::Ordering::Less),
+				},
+			Test::E => ::core::option::Option::Some(::core::cmp::Ordering::Greater),
+		}
+	};
+
+	test_derive(
+		quote! {
+			#[derive_where(PartialOrd)]
+			enum Test<T> {
+				A { field: std::marker::PhatomData<T>},
+				B { },
+				C(std::marker::PhatomData<T>),
+				D(),
+				E,
+			}
+		},
+		quote! {
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
+				#[inline]
+				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+					#discriminant
+
+					if __self_disc == __other_disc {
+						match (self, __other) {
+							(Test::A { field: ref __field }, Test::A { field: ref __other_field }) =>
+								match ::core::cmp::PartialOrd::partial_cmp(__field, __other_field) {
+									::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
+									__cmp => __cmp,
+								},
+							(Test::C(ref __0), Test::C(ref __other_0)) =>
+								match ::core::cmp::PartialOrd::partial_cmp(__0, __other_0) {
+									::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
+									__cmp => __cmp,
+								},
+							_ => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
+						}
+					} else {
+						#partial_ord
+					}
+				}
+			}
+		},
+	)
+}
+
+#[test]
+fn union_() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone, Copy)]
+			union Test<T> {
+				a: std::marker::PhantomData<T>,
+				b: u8,
+			}
+		},
+		quote! {
+			impl<T> ::core::clone::Clone for Test<T> {
+				#[inline]
+				fn clone(&self) -> Self {
+					*self
+				}
+			}
+
+			impl<T> ::core::marker::Copy for Test<T>
+			{ }
+		},
+	)
+}
+
+#[test]
+fn bound() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Ord; T)]
+			#[derive_where(PartialOrd)]
+			struct Test<T, U>(T, std::marker::PhantomData<U>);
+		},
+		quote! {
+			impl<T, U> ::core::cmp::Ord for Test<T, U>
+			where T: ::core::cmp::Ord
+			{
+				#[inline]
+				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
+					match (self, __other) {
+						(Test(ref __0, ref __1), Test(ref __other_0, ref __other_1)) =>
+							match ::core::cmp::Ord::cmp(__0, __other_0) {
+								::core::cmp::Ordering::Equal => match ::core::cmp::Ord::cmp(__1, __other_1) {
+									::core::cmp::Ordering::Equal => ::core::cmp::Ordering::Equal,
+									__cmp => __cmp,
+								},
+								__cmp => __cmp,
+							},
+					}
+				}
+			}
+
+			impl<T, U> ::core::cmp::PartialOrd for Test<T, U> {
+				#[inline]
+				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+					match (self, __other) {
+						(Test(ref __0, ref __1), Test(ref __other_0, ref __other_1)) =>
+							match ::core::cmp::PartialOrd::partial_cmp(__0, __other_0) {
+								::core::option::Option::Some(::core::cmp::Ordering::Equal) => match ::core::cmp::PartialOrd::partial_cmp(__1, __other_1) {
+									::core::option::Option::Some(::core::cmp::Ordering::Equal) => ::core::option::Option::Some(::core::cmp::Ordering::Equal),
+									__cmp => __cmp,
+								},
+								__cmp => __cmp,
+							},
+					}
+				}
+			}
+		},
+	)
+}

--- a/src/trait_/clone.rs
+++ b/src/trait_/clone.rs
@@ -1,4 +1,4 @@
-//! [`Clone`](std::clone::Clone) implementation.
+//! [`Clone`](trait@std::clone::Clone) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -6,7 +6,7 @@ use syn::{TraitBound, TraitBoundModifier, TypeParamBound};
 
 use crate::{Data, DataType, DeriveTrait, Item, SimpleType, Trait, TraitImpl};
 
-/// Dummy-struct implement [`Trait`] for [`Clone`](std::clone::Clone).
+/// Dummy-struct implement [`Trait`] for [`Clone`](trait@std::clone::Clone).
 pub struct Clone;
 
 impl TraitImpl for Clone {

--- a/src/trait_/copy.rs
+++ b/src/trait_/copy.rs
@@ -1,9 +1,9 @@
-//! [`Copy`](std::marker::Copy) implementation.
+//! [`Copy`](trait@std::marker::Copy) implementation.
 
 use crate::{DeriveTrait, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
-/// [`Copy`](std::marker::Copy).
+/// [`Copy`](trait@std::marker::Copy).
 pub struct Copy;
 
 impl TraitImpl for Copy {

--- a/src/trait_/debug.rs
+++ b/src/trait_/debug.rs
@@ -1,4 +1,4 @@
-//! [`Debug`](std::fmt::Debug) implementation.
+//! [`Debug`](trait@std::fmt::Debug) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -6,7 +6,7 @@ use quote::quote;
 use crate::{Data, DeriveTrait, Item, SimpleType, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
-/// [`Debug`](std::fmt::Debug).
+/// [`Debug`](trait@std::fmt::Debug).
 pub struct Debug;
 
 impl TraitImpl for Debug {

--- a/src/trait_/default.rs
+++ b/src/trait_/default.rs
@@ -1,4 +1,4 @@
-//! [`Default`](std::default::Default) implementation.
+//! [`Default`](trait@std::default::Default) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -6,7 +6,7 @@ use quote::quote;
 use crate::{Data, DeriveTrait, Item, SimpleType, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
-/// [`Default`](std::default::Default).
+/// [`Default`](trait@std::default::Default).
 pub struct Default;
 
 impl TraitImpl for Default {

--- a/src/trait_/eq.rs
+++ b/src/trait_/eq.rs
@@ -1,11 +1,12 @@
-//! [`Eq`](std::cmp::Eq) implementation.
+//! [`Eq`](trait@std::cmp::Eq) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{Data, DeriveTrait, Item, TraitImpl};
 
-/// Dummy-struct implement [`Trait`](crate::Trait) for [`Eq`](std::cmp::Eq).
+/// Dummy-struct implement [`Trait`](crate::Trait) for
+/// [`Eq`](trait@std::cmp::Eq).
 pub struct Eq;
 
 impl TraitImpl for Eq {

--- a/src/trait_/hash.rs
+++ b/src/trait_/hash.rs
@@ -1,4 +1,4 @@
-//! [`Hash`](std::hash::Hash) implementation.
+//! [`Hash`](trait@std::hash::Hash) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -6,7 +6,7 @@ use quote::quote;
 use crate::{Data, DataType, DeriveTrait, Item, SimpleType, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
-/// [`Hash`](std::hash::Hash).
+/// [`Hash`](trait@std::hash::Hash).
 pub struct Hash;
 
 impl TraitImpl for Hash {

--- a/src/trait_/ord.rs
+++ b/src/trait_/ord.rs
@@ -1,4 +1,4 @@
-//! [`Ord`](std::cmp::Ord) implementation.
+//! [`Ord`](trait@std::cmp::Ord) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -6,7 +6,8 @@ use quote::quote;
 use super::common_ord;
 use crate::{Data, DeriveTrait, Item, SimpleType, TraitImpl};
 
-/// Dummy-struct implement [`Trait`](crate::Trait) for [`Ord`](std::cmp::Ord).
+/// Dummy-struct implement [`Trait`](crate::Trait) for
+/// [`Ord`](trait@std::cmp::Ord).
 pub struct Ord;
 
 impl TraitImpl for Ord {

--- a/src/trait_/partial_eq.rs
+++ b/src/trait_/partial_eq.rs
@@ -1,4 +1,4 @@
-//! [`PartialEq`](std::cmp::PartialEq) implementation.
+//! [`PartialEq`](trait@std::cmp::PartialEq) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -7,7 +7,7 @@ use super::common_ord::build_incomparable_pattern;
 use crate::{Data, DeriveTrait, Item, SimpleType, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
-/// [`PartialEq`](std::cmp::PartialEq).
+/// [`PartialEq`](trait@std::cmp::PartialEq).
 pub struct PartialEq;
 
 impl TraitImpl for PartialEq {

--- a/src/trait_/partial_ord.rs
+++ b/src/trait_/partial_ord.rs
@@ -1,4 +1,4 @@
-//! [`PartialOrd`](std::cmp::PartialOrd) implementation.
+//! [`PartialOrd`](trait@std::cmp::PartialOrd) implementation.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -7,7 +7,7 @@ use super::common_ord;
 use crate::{Data, DeriveTrait, Item, SimpleType, Trait, TraitImpl};
 
 /// Dummy-struct implement [`Trait`] for
-/// [`PartialOrd`](std::cmp::PartialOrd).
+/// [`PartialOrd`](trait@std::cmp::PartialOrd).
 pub struct PartialOrd;
 
 impl TraitImpl for PartialOrd {

--- a/tests/ui/zeroize/zeroize.stderr
+++ b/tests/ui/zeroize/zeroize.stderr
@@ -22,7 +22,7 @@ error: unexpected option syntax
 16 | #[derive_where(Zeroize(crate(zeroize_)))]
    |                        ^^^^^^^^^^^^^^^
 
-error: expected expression
+error: expected an expression
   --> tests/ui/zeroize/zeroize.rs:19:32
    |
 19 | #[derive_where(Zeroize(crate = struct Test))]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -20,10 +20,7 @@ pub struct Wrapper<T = ()> {
 
 impl<T> Clone for Wrapper<T> {
 	fn clone(&self) -> Self {
-		Self {
-			data: self.data,
-			hack: self.hack,
-		}
+		*self
 	}
 }
 
@@ -81,7 +78,7 @@ impl<T> PartialEq<i32> for Wrapper<T> {
 
 impl<T> PartialOrd for Wrapper<T> {
 	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		self.data.partial_cmp(&other.data)
+		Some(self.cmp(other))
 	}
 }
 


### PR DESCRIPTION
- Addresses [`internal_features`](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html?highlight=internal_features#internal-features).
- Addresses [`clippy::incorrect_partial_ord_impl_on_ord_type`](https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_partial_ord_impl_on_ord_type).
- Addresses Rustdoc lints.
- Update UI tests.
- Stop testing `minimal-versions` on nightly.
- Don't run MSRV in scheduled runs.
- Miri doesn't need `xargo` anymore.