### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,33 +9,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        matrix:
-          - { channel: stable, features: "" }
-          - { channel: stable, features: --features safe }
-          - { channel: nightly, features: --features nightly }
-          - { channel: stable, features: --features zeroize }
-          - { channel: stable, features: --features zeroize-on-drop }
-          - { channel: nightly, features: --features safe,nightly }
-          - { channel: stable, features: --features safe,zeroize }
-          - { channel: stable, features: --features safe,zeroize-on-drop }
-          - { channel: nightly, features: --features nightly,zeroize }
-          - { channel: nightly, features: --features nightly,zeroize-on-drop }
-          - { channel: nightly, features: --all-features }
+        include:
+          - channel: stable
+            features: ""
+          - channel: stable
+            features: --features safe
+          - channel: nightly
+            features: --features nightly 
+          - channel: stable
+            features: --features zeroize
+          - channel: stable
+            features: --features zeroize-on-drop
+          - channel: nightly
+            features: --features safe,nightly
+          - channel: stable
+            features: --features safe,zeroize
+          - channel: stable
+            features: --features safe,zeroize-on-drop
+          - channel: nightly
+            features: --features nightly,zeroize
+          - channel: nightly
+            features: --features nightly,zeroize-on-drop
+          - channel: nightly
+            features: --all-features
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Update Rust
         run: |
-          rustup toolchain install ${{ matrix.matrix.channel }} --profile minimal --component clippy --allow-downgrade
-          rustup default ${{ matrix.matrix.channel }}
+          rustup toolchain install ${{ matrix.channel }} --profile minimal --component clippy --allow-downgrade
+          rustup default ${{ matrix.channel }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Clippy
         run:
-          cargo clippy --all-targets --workspace ${{ matrix.matrix.features }} -- -D warnings
+          cargo clippy --all-targets --workspace ${{ matrix.features }} -- -D warnings
       - name: Run Rustdoc
         env:
           RUSTDOCFLAGS: -D warnings
         run:
-          cargo doc --no-deps --document-private-items --workspace ${{ matrix.matrix.features }}
+          cargo doc --no-deps --document-private-items --workspace ${{ matrix.features }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 #![allow(clippy::tabs_in_doc_comments)]
 #![warn(clippy::cargo, clippy::missing_docs_in_private_items)]
+#![cfg_attr(feature = "nightly", allow(clippy::implied_bounds_in_impls))]
 #![cfg_attr(doc, allow(unknown_lints), warn(rustdoc::all))]
 
 //! # Description


### PR DESCRIPTION
It's unfortunate that we can't check code behind nightly guards without having to switch to nightly Clippy.