### PR TITLE
Enforce default discriminant type for all representations and across editions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   possible.
 - Avoid unnecessarily validating the discriminant type of enums with C
   representations in some cases.
+- Make sure to validate that enums with C representation use `isize`
+  discriminants even in the case of an edition change.
 
 ## [1.2.4] - 2023-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use safe casting in `PartialOrd` and `Ord` implementations in more cases when
   possible.
-- Avoid unnecessarily validating the discriminant type of enums with C
-  representations in some cases.
-- Make sure to validate that enums with C representation use `isize`
-  discriminants even in the case of an edition change.
+- Avoid unnecessarily validating the default discriminant type in some cases.
+- Apply default enum discriminant type validation to all representations and
+  make it cross-edition safe.
 
 ## [1.2.4] - 2023-09-01
 

--- a/README.md
+++ b/README.md
@@ -275,11 +275,9 @@ supported.
 Unions only support [`Clone`] and [`Copy`].
 
 [`PartialOrd`] and [`Ord`] need to determine the discriminant type to
-function correctly. Unfortunately, according to the specification, the C
-representation without an integer representation doesn't have a
-platform-independent discriminant type. Therefor a check is inserted to
-ascertain that discriminants of enums with a C representation have the
-[`isize`] type, which is currently the case for all known platforms.
+function correctly. To protect against a potential future change to the
+default discriminant type, some compile-time validation is inserted to
+ascertain that the type remains `isize`.
 
 ### `no_std` support
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,11 +314,9 @@
 //! Unions only support [`Clone`] and [`Copy`].
 //!
 //! [`PartialOrd`] and [`Ord`] need to determine the discriminant type to
-//! function correctly. Unfortunately, according to the specification, the C
-//! representation without an integer representation doesn't have a
-//! platform-independent discriminant type. Therefor a check is inserted to
-//! ascertain that discriminants of enums with a C representation have the
-//! [`isize`] type, which is currently the case for all known platforms.
+//! function correctly. To protect against a potential future change to the
+//! default discriminant type, some compile-time validation is inserted to
+//! ascertain that the type remains `isize`.
 //!
 //! ## `no_std` support
 //!

--- a/src/test/discriminant.rs
+++ b/src/test/discriminant.rs
@@ -346,8 +346,9 @@ fn repr_c() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		#[repr(C)]
-		enum EnsureReprCIsIsize { Test = 0_isize }
+		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
+		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
+		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
 
 		const fn __discriminant(__this: &Test) -> isize {
 			match __this {
@@ -445,8 +446,9 @@ fn repr_c_clone() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		#[repr(C)]
-		enum EnsureReprCIsIsize { Test = 0_isize }
+		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
+		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
+		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
 
 		::core::cmp::PartialOrd::partial_cmp(&(::core::clone::Clone::clone(self) as isize), &(::core::clone::Clone::clone(__other) as isize))
 	};
@@ -550,8 +552,9 @@ fn repr_c_copy() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		#[repr(C)]
-		enum EnsureReprCIsIsize { Test = 0_isize }
+		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
+		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
+		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
 
 		::core::cmp::PartialOrd::partial_cmp(&(*self as isize), &(*__other as isize))
 	};
@@ -637,8 +640,9 @@ fn repr_c_reverse() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		#[repr(C)]
-		enum EnsureReprCIsIsize { Test = 0_isize }
+		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 2;
+		const __ENSURE_REPR_C_IS_ISIZE_B: isize = 1;
+		const __ENSURE_REPR_C_IS_ISIZE_C: isize = 0;
 
 		const fn __discriminant(__this: &Test) -> isize {
 			match __this {
@@ -688,8 +692,10 @@ fn repr_c_mix() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		#[repr(C)]
-		enum EnsureReprCIsIsize { Test = 0_isize }
+		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 1;
+		const __ENSURE_REPR_C_IS_ISIZE_B: isize = 0;
+		const __ENSURE_REPR_C_IS_ISIZE_C: isize = 2;
+		const __ENSURE_REPR_C_IS_ISIZE_D: isize = (2) + 1;
 
 		const fn __discriminant(__this: &Test) -> isize {
 			match __this {
@@ -741,8 +747,11 @@ fn repr_c_skip() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		#[repr(C)]
-		enum EnsureReprCIsIsize { Test = 0_isize }
+		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
+		const __ENSURE_REPR_C_IS_ISIZE_B: isize = 3;
+		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (3) + 1;
+		const __ENSURE_REPR_C_IS_ISIZE_D: isize = (3) + 2;
+		const __ENSURE_REPR_C_IS_ISIZE_E: isize = (3) + 3;
 
 		const fn __discriminant(__this: &Test) -> isize {
 			match __this {
@@ -796,14 +805,15 @@ fn repr_c_expr() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		#[repr(C)]
-		enum EnsureReprCIsIsize { Test = 0_isize }
+		const __ENSURE_REPR_C_IS_ISIZE_A: isize = isize::MAX - 2;
+		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (isize::MAX - 2) + 1;
+		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (isize::MAX - 2) + 2;
 
 		const fn __discriminant(__this: &Test) -> isize {
 			match __this {
-				Test::A => u64::MAX - 2,
-				Test::B => (u64::MAX - 2) + 1,
-				Test::C => (u64::MAX - 2) + 2
+				Test::A => isize::MAX - 2,
+				Test::B => (isize::MAX - 2) + 1,
+				Test::C => (isize::MAX - 2) + 2
 			}
 		}
 
@@ -815,7 +825,7 @@ fn repr_c_expr() -> Result<()> {
 			#[derive_where(PartialOrd)]
 			#[repr(C)]
 			enum Test {
-				A = u64::MAX - 2,
+				A = isize::MAX - 2,
 				B,
 				#[derive_where(incomparable)]
 				C,

--- a/src/test/discriminant.rs
+++ b/src/test/discriminant.rs
@@ -346,15 +346,15 @@ fn repr_c() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
-		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
-		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
-
 		const fn __discriminant(__this: &Test) -> isize {
+			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
+			const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
+			const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
+
 			match __this {
-				Test::A => 0,
-				Test::B => (0) + 1,
-				Test::C => (0) + 2
+				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
+				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
+				Test::C => __ENSURE_REPR_C_IS_ISIZE_C
 			}
 		}
 
@@ -640,15 +640,15 @@ fn repr_c_reverse() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 2;
-		const __ENSURE_REPR_C_IS_ISIZE_B: isize = 1;
-		const __ENSURE_REPR_C_IS_ISIZE_C: isize = 0;
-
 		const fn __discriminant(__this: &Test) -> isize {
+			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 2;
+			const __ENSURE_REPR_C_IS_ISIZE_B: isize = 1;
+			const __ENSURE_REPR_C_IS_ISIZE_C: isize = 0;
+
 			match __this {
-				Test::A => 2,
-				Test::B => 1,
-				Test::C => 0
+				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
+				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
+				Test::C => __ENSURE_REPR_C_IS_ISIZE_C
 			}
 		}
 
@@ -692,17 +692,17 @@ fn repr_c_mix() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 1;
-		const __ENSURE_REPR_C_IS_ISIZE_B: isize = 0;
-		const __ENSURE_REPR_C_IS_ISIZE_C: isize = 2;
-		const __ENSURE_REPR_C_IS_ISIZE_D: isize = (2) + 1;
-
 		const fn __discriminant(__this: &Test) -> isize {
+			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 1;
+			const __ENSURE_REPR_C_IS_ISIZE_B: isize = 0;
+			const __ENSURE_REPR_C_IS_ISIZE_C: isize = 2;
+			const __ENSURE_REPR_C_IS_ISIZE_D: isize = (2) + 1;
+
 			match __this {
-				Test::A => 1,
-				Test::B => 0,
-				Test::C => 2,
-				Test::D => (2) + 1
+				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
+				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
+				Test::C => __ENSURE_REPR_C_IS_ISIZE_C,
+				Test::D => __ENSURE_REPR_C_IS_ISIZE_D
 			}
 		}
 
@@ -747,19 +747,19 @@ fn repr_c_skip() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
-		const __ENSURE_REPR_C_IS_ISIZE_B: isize = 3;
-		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (3) + 1;
-		const __ENSURE_REPR_C_IS_ISIZE_D: isize = (3) + 2;
-		const __ENSURE_REPR_C_IS_ISIZE_E: isize = (3) + 3;
-
 		const fn __discriminant(__this: &Test) -> isize {
+			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
+			const __ENSURE_REPR_C_IS_ISIZE_B: isize = 3;
+			const __ENSURE_REPR_C_IS_ISIZE_C: isize = (3) + 1;
+			const __ENSURE_REPR_C_IS_ISIZE_D: isize = (3) + 2;
+			const __ENSURE_REPR_C_IS_ISIZE_E: isize = (3) + 3;
+
 			match __this {
-				Test::A => 0,
-				Test::B => 3,
-				Test::C => (3) + 1,
-				Test::D => (3) + 2,
-				Test::E => (3) + 3
+				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
+				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
+				Test::C => __ENSURE_REPR_C_IS_ISIZE_C,
+				Test::D => __ENSURE_REPR_C_IS_ISIZE_D,
+				Test::E => __ENSURE_REPR_C_IS_ISIZE_E
 			}
 		}
 
@@ -805,15 +805,15 @@ fn repr_c_expr() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		const __ENSURE_REPR_C_IS_ISIZE_A: isize = isize::MAX - 2;
-		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (isize::MAX - 2) + 1;
-		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (isize::MAX - 2) + 2;
-
 		const fn __discriminant(__this: &Test) -> isize {
+			const __ENSURE_REPR_C_IS_ISIZE_A: isize = isize::MAX - 2;
+			const __ENSURE_REPR_C_IS_ISIZE_B: isize = (isize::MAX - 2) + 1;
+			const __ENSURE_REPR_C_IS_ISIZE_C: isize = (isize::MAX - 2) + 2;
+
 			match __this {
-				Test::A => isize::MAX - 2,
-				Test::B => (isize::MAX - 2) + 1,
-				Test::C => (isize::MAX - 2) + 2
+				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
+				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
+				Test::C => __ENSURE_REPR_C_IS_ISIZE_C
 			}
 		}
 

--- a/src/test/discriminant.rs
+++ b/src/test/discriminant.rs
@@ -15,10 +15,14 @@ fn default() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
+			const __VALIDATE_ISIZE_A: isize = 0;
+			const __VALIDATE_ISIZE_B: isize = (0) + 1;
+			const __VALIDATE_ISIZE_C: isize = (0) + 2;
+
 			match __this {
-				Test::A => 0,
-				Test::B => (0) + 1,
-				Test::C => (0) + 2
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C
 			}
 		}
 
@@ -61,6 +65,10 @@ fn default_clone() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
+		const __VALIDATE_ISIZE_A: isize = 0;
+		const __VALIDATE_ISIZE_B: isize = (0) + 1;
+		const __VALIDATE_ISIZE_C: isize = (0) + 2;
+
 		::core::cmp::PartialOrd::partial_cmp(&(::core::clone::Clone::clone(self) as isize), &(::core::clone::Clone::clone(__other) as isize))
 	};
 
@@ -111,6 +119,10 @@ fn default_copy() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
+		const __VALIDATE_ISIZE_A: isize = 0;
+		const __VALIDATE_ISIZE_B: isize = (0) + 1;
+		const __VALIDATE_ISIZE_C: isize = (0) + 2;
+
 		::core::cmp::PartialOrd::partial_cmp(&(*self as isize), &(*__other as isize))
 	};
 
@@ -153,10 +165,14 @@ fn default_reverse() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
+			const __VALIDATE_ISIZE_A: isize = 2;
+			const __VALIDATE_ISIZE_B: isize = 1;
+			const __VALIDATE_ISIZE_C: isize = 0;
+
 			match __this {
-				Test::A => 2,
-				Test::B => 1,
-				Test::C => 0
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C
 			}
 		}
 
@@ -200,11 +216,16 @@ fn default_mix() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
+			const __VALIDATE_ISIZE_A: isize = 1;
+			const __VALIDATE_ISIZE_B: isize = 0;
+			const __VALIDATE_ISIZE_C: isize = 2;
+			const __VALIDATE_ISIZE_D: isize = (2) + 1;
+
 			match __this {
-				Test::A => 1,
-				Test::B => 0,
-				Test::C => 2,
-				Test::D => (2) + 1
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C,
+				Test::D => __VALIDATE_ISIZE_D
 			}
 		}
 
@@ -249,12 +270,18 @@ fn default_skip() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
+			const __VALIDATE_ISIZE_A: isize = 0;
+			const __VALIDATE_ISIZE_B: isize = 3;
+			const __VALIDATE_ISIZE_C: isize = (3) + 1;
+			const __VALIDATE_ISIZE_D: isize = (3) + 2;
+			const __VALIDATE_ISIZE_E: isize = (3) + 3;
+
 			match __this {
-				Test::A => 0,
-				Test::B => 3,
-				Test::C => (3) + 1,
-				Test::D => (3) + 2,
-				Test::E => (3) + 3
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C,
+				Test::D => __VALIDATE_ISIZE_D,
+				Test::E => __VALIDATE_ISIZE_E
 			}
 		}
 
@@ -300,10 +327,14 @@ fn default_expr() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
+			const __VALIDATE_ISIZE_A: isize = isize::MAX - 2;
+			const __VALIDATE_ISIZE_B: isize = (isize::MAX - 2) + 1;
+			const __VALIDATE_ISIZE_C: isize = (isize::MAX - 2) + 2;
+
 			match __this {
-				Test::A => isize::MAX - 2,
-				Test::B => (isize::MAX - 2) + 1,
-				Test::C => (isize::MAX - 2) + 2
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C
 			}
 		}
 
@@ -347,14 +378,14 @@ fn repr_c() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
-			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
-			const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
-			const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
+			const __VALIDATE_ISIZE_A: isize = 0;
+			const __VALIDATE_ISIZE_B: isize = (0) + 1;
+			const __VALIDATE_ISIZE_C: isize = (0) + 2;
 
 			match __this {
-				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
-				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
-				Test::C => __ENSURE_REPR_C_IS_ISIZE_C
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C
 			}
 		}
 
@@ -446,9 +477,9 @@ fn repr_c_clone() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
-		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
-		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
+		const __VALIDATE_ISIZE_A: isize = 0;
+		const __VALIDATE_ISIZE_B: isize = (0) + 1;
+		const __VALIDATE_ISIZE_C: isize = (0) + 2;
 
 		::core::cmp::PartialOrd::partial_cmp(&(::core::clone::Clone::clone(self) as isize), &(::core::clone::Clone::clone(__other) as isize))
 	};
@@ -552,9 +583,9 @@ fn repr_c_copy() -> Result<()> {
 	};
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
-		const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
-		const __ENSURE_REPR_C_IS_ISIZE_B: isize = (0) + 1;
-		const __ENSURE_REPR_C_IS_ISIZE_C: isize = (0) + 2;
+		const __VALIDATE_ISIZE_A: isize = 0;
+		const __VALIDATE_ISIZE_B: isize = (0) + 1;
+		const __VALIDATE_ISIZE_C: isize = (0) + 2;
 
 		::core::cmp::PartialOrd::partial_cmp(&(*self as isize), &(*__other as isize))
 	};
@@ -641,14 +672,14 @@ fn repr_c_reverse() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
-			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 2;
-			const __ENSURE_REPR_C_IS_ISIZE_B: isize = 1;
-			const __ENSURE_REPR_C_IS_ISIZE_C: isize = 0;
+			const __VALIDATE_ISIZE_A: isize = 2;
+			const __VALIDATE_ISIZE_B: isize = 1;
+			const __VALIDATE_ISIZE_C: isize = 0;
 
 			match __this {
-				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
-				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
-				Test::C => __ENSURE_REPR_C_IS_ISIZE_C
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C
 			}
 		}
 
@@ -693,16 +724,16 @@ fn repr_c_mix() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
-			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 1;
-			const __ENSURE_REPR_C_IS_ISIZE_B: isize = 0;
-			const __ENSURE_REPR_C_IS_ISIZE_C: isize = 2;
-			const __ENSURE_REPR_C_IS_ISIZE_D: isize = (2) + 1;
+			const __VALIDATE_ISIZE_A: isize = 1;
+			const __VALIDATE_ISIZE_B: isize = 0;
+			const __VALIDATE_ISIZE_C: isize = 2;
+			const __VALIDATE_ISIZE_D: isize = (2) + 1;
 
 			match __this {
-				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
-				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
-				Test::C => __ENSURE_REPR_C_IS_ISIZE_C,
-				Test::D => __ENSURE_REPR_C_IS_ISIZE_D
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C,
+				Test::D => __VALIDATE_ISIZE_D
 			}
 		}
 
@@ -748,18 +779,18 @@ fn repr_c_skip() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
-			const __ENSURE_REPR_C_IS_ISIZE_A: isize = 0;
-			const __ENSURE_REPR_C_IS_ISIZE_B: isize = 3;
-			const __ENSURE_REPR_C_IS_ISIZE_C: isize = (3) + 1;
-			const __ENSURE_REPR_C_IS_ISIZE_D: isize = (3) + 2;
-			const __ENSURE_REPR_C_IS_ISIZE_E: isize = (3) + 3;
+			const __VALIDATE_ISIZE_A: isize = 0;
+			const __VALIDATE_ISIZE_B: isize = 3;
+			const __VALIDATE_ISIZE_C: isize = (3) + 1;
+			const __VALIDATE_ISIZE_D: isize = (3) + 2;
+			const __VALIDATE_ISIZE_E: isize = (3) + 3;
 
 			match __this {
-				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
-				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
-				Test::C => __ENSURE_REPR_C_IS_ISIZE_C,
-				Test::D => __ENSURE_REPR_C_IS_ISIZE_D,
-				Test::E => __ENSURE_REPR_C_IS_ISIZE_E
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C,
+				Test::D => __VALIDATE_ISIZE_D,
+				Test::E => __VALIDATE_ISIZE_E
 			}
 		}
 
@@ -806,14 +837,14 @@ fn repr_c_expr() -> Result<()> {
 	#[cfg(not(feature = "nightly"))]
 	let partial_ord = quote! {
 		const fn __discriminant(__this: &Test) -> isize {
-			const __ENSURE_REPR_C_IS_ISIZE_A: isize = isize::MAX - 2;
-			const __ENSURE_REPR_C_IS_ISIZE_B: isize = (isize::MAX - 2) + 1;
-			const __ENSURE_REPR_C_IS_ISIZE_C: isize = (isize::MAX - 2) + 2;
+			const __VALIDATE_ISIZE_A: isize = isize::MAX - 2;
+			const __VALIDATE_ISIZE_B: isize = (isize::MAX - 2) + 1;
+			const __VALIDATE_ISIZE_C: isize = (isize::MAX - 2) + 2;
 
 			match __this {
-				Test::A => __ENSURE_REPR_C_IS_ISIZE_A,
-				Test::B => __ENSURE_REPR_C_IS_ISIZE_B,
-				Test::C => __ENSURE_REPR_C_IS_ISIZE_C
+				Test::A => __VALIDATE_ISIZE_A,
+				Test::B => __VALIDATE_ISIZE_B,
+				Test::C => __VALIDATE_ISIZE_C
 			}
 		}
 

--- a/src/trait_/common_ord.rs
+++ b/src/trait_/common_ord.rs
@@ -380,10 +380,17 @@ fn build_discriminant_comparison(
 		.zip(discriminants)
 		.map(|(variant, discriminant)| {
 			let pattern = variant.self_pattern();
-			let discriminant = discriminant.deref();
 
-			quote! {
-				#pattern => #discriminant
+			if validate_c.is_some() {
+				let discriminant = format_ident!("__ENSURE_REPR_C_IS_ISIZE_{}", variant.ident);
+
+				quote! {
+					#pattern => #discriminant
+				}
+			} else {
+				quote! {
+					#pattern => #discriminant
+				}
 			}
 		});
 
@@ -399,9 +406,9 @@ fn build_discriminant_comparison(
 	} = generics;
 
 	quote! {
-		#validate_c
-
 		const fn __discriminant #imp(__this: &#item #ty) -> #repr #where_clause {
+			#validate_c
+
 			match __this {
 				#(#variants),*
 			}


### PR DESCRIPTION
See [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/enum.20discriminant.20size/near/388771801).

Yanking time ... cry me a river ...