### PR TITLE
Fix wrong usage of `Copy` in `Clone` when bounds are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Use the `Copy` implementation for `Clone` only if no bounds are present.
+
 ## [1.2.5] - 2023-09-03
 
 ### Changed

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -152,7 +152,9 @@ fn check_trait_bounds() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					*self
+					match self {
+						Test(ref __field_0, ref __field_1) => Test(::core::clone::Clone::clone(__field_0), ::core::clone::Clone::clone(__field_1)),
+					}
 				}
 			}
 
@@ -277,7 +279,9 @@ fn check_multiple_trait_bounds() -> Result<()> {
 			{
 				#[inline]
 				fn clone(&self) -> Self {
-					*self
+					match self {
+						Test(ref __field_0, ref __field_1) => Test(::core::clone::Clone::clone(__field_0), ::core::clone::Clone::clone(__field_1)),
+					}
 				}
 			}
 

--- a/src/trait_/clone.rs
+++ b/src/trait_/clone.rs
@@ -42,7 +42,7 @@ impl TraitImpl for Clone {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		any_bound: bool,
 		item: &Item,
 		_generics: &SplitGenerics<'_>,
 		traits: &[DeriveTrait],
@@ -50,7 +50,7 @@ impl TraitImpl for Clone {
 		body: &TokenStream,
 	) -> TokenStream {
 		// Special implementation for items also implementing `Copy`.
-		if traits.iter().any(|trait_| trait_ == Trait::Copy) {
+		if !any_bound && traits.iter().any(|trait_| trait_ == Trait::Copy) {
 			return quote! {
 				#[inline]
 				fn clone(&self) -> Self { *self }
@@ -85,12 +85,12 @@ impl TraitImpl for Clone {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
+		any_bound: bool,
 		traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {
-		if traits.iter().any(|trait_| trait_ == Trait::Copy) {
+		if !any_bound && traits.iter().any(|trait_| trait_ == Trait::Copy) {
 			return TokenStream::new();
 		}
 

--- a/tests/bound.rs
+++ b/tests/bound.rs
@@ -4,7 +4,22 @@ use std::marker::PhantomData;
 
 use derive_where::derive_where;
 
-use self::util::AssertClone;
+use self::util::{AssertClone, AssertCopy};
+
+#[test]
+fn bound() {
+	#[derive_where(Clone, Copy; T)]
+	struct Test<T, U>(T, std::marker::PhantomData<U>);
+
+	let test_1 = Test(42, PhantomData::<()>);
+
+	let _ = AssertClone(&test_1);
+	let _ = AssertCopy(&test_1);
+
+	#[allow(clippy::clone_on_copy)]
+	let test_clone = test_1.clone();
+	assert_eq!(test_clone.0, 42);
+}
 
 #[test]
 fn custom_generic() {


### PR DESCRIPTION
Still going to add some integration tests.

Fixes #86.