### PR TITLE
Apply `#[automatically_derived]` to all generated implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Apply `#[automatically_derived]` to all generated implementations.
+
 ## [1.2.6] - 2023-12-04
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,6 +641,7 @@ fn generate_impl(
 	let ident = item.ident();
 	let path = trait_.impl_path(trait_);
 	let mut output = quote! {
+		#[automatically_derived]
 		impl #imp #path for #ident #ty
 		#where_clause
 		{
@@ -650,6 +651,7 @@ fn generate_impl(
 
 	if let Some((path, body)) = trait_.additional_impl(trait_) {
 		output.extend(quote! {
+			#[automatically_derived]
 			impl #imp #path for #ident #ty
 			#where_clause
 			{

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -13,6 +13,7 @@ fn struct_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -20,9 +21,11 @@ fn struct_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 
+			#[automatically_derived]
 			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -35,12 +38,14 @@ fn struct_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::default::Default for Test<T> {
 				fn default() -> Self {
 					Test { field: ::core::default::Default::default() }
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::Eq for Test<T> {
 				#[inline]
 				fn assert_receiver_is_total_eq(&self) {
@@ -51,6 +56,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
@@ -59,6 +65,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -72,6 +79,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -82,6 +90,7 @@ fn struct_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -100,6 +109,7 @@ fn tuple() -> Result<()> {
 			struct Test<T>(std::marker::PhantomData<T>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -107,9 +117,11 @@ fn tuple() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 
+			#[automatically_derived]
 			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -122,12 +134,14 @@ fn tuple() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::default::Default for Test<T> {
 				fn default() -> Self {
 					Test(::core::default::Default::default())
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::Eq for Test<T> {
 				#[inline]
 				fn assert_receiver_is_total_eq(&self) {
@@ -138,6 +152,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
@@ -146,6 +161,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -159,6 +175,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -169,6 +186,7 @@ fn tuple() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -223,6 +241,7 @@ fn enum_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -230,9 +249,11 @@ fn enum_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 
+			#[automatically_derived]
 			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -259,12 +280,14 @@ fn enum_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::default::Default for Test<T> {
 				fn default() -> Self {
 					Test::E
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::Eq for Test<T> {
 				#[inline]
 				fn assert_receiver_is_total_eq(&self) {
@@ -276,6 +299,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {
 				fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
 					match self {
@@ -300,6 +324,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -325,6 +350,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -342,6 +368,7 @@ fn enum_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -363,6 +390,7 @@ fn union_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -370,6 +398,7 @@ fn union_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 		},

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -11,6 +11,7 @@ fn bound() -> Result<()> {
 			struct Test<T, U>(T, std::marker::PhantomData<U>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T, U> ::core::clone::Clone for Test<T, U>
 			where T: ::core::clone::Clone
 			{
@@ -33,6 +34,7 @@ fn bound_multiple() -> Result<()> {
 			struct Test<T, U, V>((T, U), std::marker::PhantomData<V>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T, U, V> ::core::clone::Clone for Test<T, U, V>
 			where
 				T: ::core::clone::Clone,
@@ -57,6 +59,7 @@ fn custom_bound() -> Result<()> {
 			struct Test<T>(T);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T>
 			where T: Copy
 			{
@@ -79,6 +82,7 @@ fn where_() -> Result<()> {
 			struct Test<T, U>(T, std::marker::PhantomData<U>) where T: std::fmt::Debug;
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T, U> ::core::clone::Clone for Test<T, U>
 			where
 				T: std::fmt::Debug,
@@ -103,6 +107,7 @@ fn associated_type() -> Result<()> {
 			struct Test<T>(<T as std::ops::Deref>::Target);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T>
 			where <T as std::ops::Deref>::Target: ::core::clone::Clone
 			{
@@ -125,6 +130,7 @@ fn associated_type_custom_bound() -> Result<()> {
 			struct Test<T>(<T as std::ops::Deref>::Target);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T>
 			where <T as std::ops::Deref>::Target: Copy
 			{
@@ -147,6 +153,7 @@ fn check_trait_bounds() -> Result<()> {
 			struct Test<T, U>(T, std::marker::PhantomData<U>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T, U> ::core::clone::Clone for Test<T, U>
 			where T: ::core::clone::Clone
 			{
@@ -158,10 +165,12 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::marker::Copy for Test<T, U>
 			where T: ::core::marker::Copy
 			{ }
 
+			#[automatically_derived]
 			impl<T, U> ::core::fmt::Debug for Test<T, U>
 			where T: ::core::fmt::Debug
 			{
@@ -177,6 +186,7 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::default::Default for Test<T, U>
 			where T: ::core::default::Default
 			{
@@ -185,6 +195,7 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::cmp::Eq for Test<T, U>
 			where T: ::core::cmp::Eq
 			{
@@ -198,6 +209,7 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::hash::Hash for Test<T, U>
 			where T: ::core::hash::Hash
 			{
@@ -211,6 +223,7 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::cmp::Ord for Test<T, U>
 			where T: ::core::cmp::Ord
 			{
@@ -229,6 +242,7 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::cmp::PartialEq for Test<T, U>
 			where T: ::core::cmp::PartialEq
 			{
@@ -243,6 +257,7 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::cmp::PartialOrd for Test<T, U>
 			where T: ::core::cmp::PartialOrd
 			{
@@ -272,6 +287,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 			struct Test<T, U, V>(T, std::marker::PhantomData<(U, V)>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T, U, V> ::core::clone::Clone for Test<T, U, V>
 			where
 				T: ::core::clone::Clone,
@@ -285,12 +301,14 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::marker::Copy for Test<T, U, V>
 			where
 				T: ::core::marker::Copy,
 				U: ::core::marker::Copy
 			{ }
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::fmt::Debug for Test<T, U, V>
 			where
 				T: ::core::fmt::Debug,
@@ -308,6 +326,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::default::Default for Test<T, U, V>
 			where
 				T: ::core::default::Default,
@@ -318,6 +337,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::cmp::Eq for Test<T, U, V>
 			where
 				T: ::core::cmp::Eq,
@@ -333,6 +353,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::hash::Hash for Test<T, U, V>
 			where
 				T: ::core::hash::Hash,
@@ -348,6 +369,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::cmp::Ord for Test<T, U, V>
 			where
 				T: ::core::cmp::Ord,
@@ -368,6 +390,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::cmp::PartialEq for Test<T, U, V>
 			where
 				T: ::core::cmp::PartialEq,
@@ -384,6 +407,7 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U, V> ::core::cmp::PartialOrd for Test<T, U, V>
 			where
 				T: ::core::cmp::PartialOrd,

--- a/src/test/clone.rs
+++ b/src/test/clone.rs
@@ -13,6 +13,7 @@ fn struct_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -33,6 +34,7 @@ fn tuple() -> Result<()> {
 			struct Test<T>(std::marker::PhantomData<T>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -59,6 +61,7 @@ fn enum_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -86,6 +89,7 @@ fn union_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {

--- a/src/test/discriminant.rs
+++ b/src/test/discriminant.rs
@@ -40,6 +40,7 @@ fn default() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -83,6 +84,7 @@ fn default_clone() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::clone::Clone for Test {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -94,6 +96,7 @@ fn default_clone() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -137,8 +140,10 @@ fn default_copy() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::marker::Copy for Test { }
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -190,6 +195,7 @@ fn default_reverse() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -244,6 +250,7 @@ fn default_mix() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -301,6 +308,7 @@ fn default_skip() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -352,6 +360,7 @@ fn default_expr() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -404,6 +413,7 @@ fn repr_c() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -452,6 +462,7 @@ fn repr_c_without_discriminant() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -496,6 +507,7 @@ fn repr_c_clone() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::clone::Clone for Test {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -507,6 +519,7 @@ fn repr_c_clone() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -547,6 +560,7 @@ fn repr_c_clone_without_discriminant() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::clone::Clone for Test {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -558,6 +572,7 @@ fn repr_c_clone_without_discriminant() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -602,8 +617,10 @@ fn repr_c_copy() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::marker::Copy for Test { }
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -644,8 +661,10 @@ fn repr_c_copy_without_discriminant() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::marker::Copy for Test { }
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -698,6 +717,7 @@ fn repr_c_reverse() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -753,6 +773,7 @@ fn repr_c_mix() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -811,6 +832,7 @@ fn repr_c_skip() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -863,6 +885,7 @@ fn repr_c_expr() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -924,6 +947,7 @@ fn repr_c_with_value() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -994,6 +1018,7 @@ fn repr_c_with_value_reverse() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1064,6 +1089,7 @@ fn repr_c_with_value_mix() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1136,6 +1162,7 @@ fn repr_c_with_value_skip() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1206,6 +1233,7 @@ fn repr_c_with_value_expr() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1270,6 +1298,7 @@ fn repr() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1310,6 +1339,7 @@ fn repr_clone() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::clone::Clone for Test {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -1321,6 +1351,7 @@ fn repr_clone() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1361,8 +1392,10 @@ fn repr_copy() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::marker::Copy for Test { }
 
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1418,6 +1451,7 @@ fn repr_reverse() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1475,6 +1509,7 @@ fn repr_mix() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1534,6 +1569,7 @@ fn repr_skip() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1589,6 +1625,7 @@ fn repr_expr() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1650,6 +1687,7 @@ fn repr_with_value() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1720,6 +1758,7 @@ fn repr_with_value_reverse() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1790,6 +1829,7 @@ fn repr_with_value_mix() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1862,6 +1902,7 @@ fn repr_with_value_skip() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -1932,6 +1973,7 @@ fn repr_with_value_expr() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {

--- a/src/test/enum_.rs
+++ b/src/test/enum_.rs
@@ -14,6 +14,7 @@ fn default_struct() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::default::Default for Test<T>
 			where T: ::core::default::Default
 			{
@@ -36,6 +37,7 @@ fn default_tuple() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::default::Default for Test<T>
 			where T: ::core::default::Default
 			{
@@ -59,6 +61,7 @@ fn default_unit() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::default::Default for Test<T>
 			where T: ::core::default::Default
 			{
@@ -80,6 +83,7 @@ fn one_data() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -90,6 +94,7 @@ fn one_data() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -147,6 +152,7 @@ fn two_data() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -164,6 +170,7 @@ fn two_data() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -229,6 +236,7 @@ fn unit() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -244,6 +252,7 @@ fn unit() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -304,6 +313,7 @@ fn struct_unit() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -319,6 +329,7 @@ fn struct_unit() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -379,6 +390,7 @@ fn tuple_unit() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialEq for Test<T> {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -394,6 +406,7 @@ fn tuple_unit() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {

--- a/src/test/incomparable.rs
+++ b/src/test/incomparable.rs
@@ -20,6 +20,7 @@ fn variants() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -34,6 +35,8 @@ fn variants() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -85,6 +88,7 @@ fn enum_empty_and_empty_incomparable_variants() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -98,6 +102,8 @@ fn enum_empty_and_empty_incomparable_variants() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -124,6 +130,7 @@ fn enum_empty_and_non_empty_incomparable_variants() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -137,6 +144,8 @@ fn enum_empty_and_non_empty_incomparable_variants() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -165,6 +174,7 @@ fn enum_empty_and_multiple_incomparable_variants() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -178,6 +188,8 @@ fn enum_empty_and_multiple_incomparable_variants() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -207,6 +219,7 @@ fn enum_skipped_and_incomparable_variant() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -220,6 +233,8 @@ fn enum_skipped_and_incomparable_variant() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -246,6 +261,7 @@ fn enum_non_empty_and_incomparable_variant() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -261,6 +277,8 @@ fn enum_non_empty_and_incomparable_variant() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -295,6 +313,7 @@ fn enum_incomparable_and_skipped_variant() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
@@ -308,6 +327,8 @@ fn enum_incomparable_and_skipped_variant() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -331,12 +352,15 @@ fn items() -> Result<()> {
 			enum Test{}
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					false
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -352,12 +376,15 @@ fn items() -> Result<()> {
 			struct Test;
 		},
 		quote! {
+			#[automatically_derived]
 			impl ::core::cmp::PartialEq for Test {
 				#[inline]
 				fn eq(&self, __other: &Self) -> bool {
 					false
 				}
 			}
+
+			#[automatically_derived]
 			impl ::core::cmp::PartialOrd for Test {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {

--- a/src/test/misc.rs
+++ b/src/test/misc.rs
@@ -17,6 +17,7 @@ fn ignore_foreign_attribute() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::default::Default for Test<T>
 			where T: ::core::default::Default
 			{

--- a/src/test/partial_ord.rs
+++ b/src/test/partial_ord.rs
@@ -13,6 +13,7 @@ fn struct_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -37,6 +38,7 @@ fn tuple() -> Result<()> {
 			struct Test<T>(std::marker::PhantomData<T>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -96,6 +98,7 @@ fn enum_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::PartialOrd for Test<T> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
@@ -135,6 +138,7 @@ fn union_() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::clone::Clone for Test<T> {
 				#[inline]
 				fn clone(&self) -> Self {
@@ -142,6 +146,7 @@ fn union_() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> ::core::marker::Copy for Test<T>
 			{ }
 		},
@@ -157,6 +162,7 @@ fn bound() -> Result<()> {
 			struct Test<T, U>(T, std::marker::PhantomData<U>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T, U> ::core::cmp::Ord for Test<T, U>
 			where T: ::core::cmp::Ord
 			{
@@ -175,6 +181,7 @@ fn bound() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::core::cmp::PartialOrd for Test<T, U> {
 				#[inline]
 				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {

--- a/src/test/skip.rs
+++ b/src/test/skip.rs
@@ -12,6 +12,7 @@ fn struct_inner() -> Result<()> {
 			struct Test<T>(std::marker::PhantomData<T>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -37,6 +38,7 @@ fn enum_inner() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::fmt::Debug for Test<T> {
 				fn fmt(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 					match self {
@@ -60,6 +62,7 @@ fn struct_empty() -> Result<()> {
 			struct Test<T>(std::marker::PhantomData<T>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -81,6 +84,7 @@ fn variant_empty() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -123,6 +127,7 @@ fn variants_empty() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
@@ -171,6 +176,7 @@ fn variants_partly_empty() -> Result<()> {
 			}
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::cmp::Ord for Test<T> {
 				#[inline]
 				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {

--- a/src/test/zeroize.rs
+++ b/src/test/zeroize.rs
@@ -11,6 +11,7 @@ fn basic() -> Result<()> {
 			struct Test<T>(std::marker::PhantomData<T>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::zeroize::Zeroize for Test<T> {
 				fn zeroize(&mut self) {
 					use ::zeroize::Zeroize;
@@ -35,6 +36,7 @@ fn drop() -> Result<()> {
 		},
 		#[cfg(not(feature = "zeroize-on-drop"))]
 		quote! {
+			#[automatically_derived]
 			impl<T, U> ::core::ops::Drop for Test<T, U>
 			where T: ::zeroize::ZeroizeOnDrop
 			{
@@ -45,6 +47,7 @@ fn drop() -> Result<()> {
 		},
 		#[cfg(feature = "zeroize-on-drop")]
 		quote! {
+			#[automatically_derived]
 			impl<T, U> ::core::ops::Drop for Test<T, U>
 			where T: ::zeroize::ZeroizeOnDrop
 			{
@@ -61,6 +64,7 @@ fn drop() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T, U> ::zeroize::ZeroizeOnDrop for Test<T, U>
 			where T: ::zeroize::ZeroizeOnDrop
 			{ }
@@ -72,6 +76,7 @@ fn drop() -> Result<()> {
 fn both() -> Result<()> {
 	#[cfg(not(feature = "zeroize-on-drop"))]
 	let drop = quote! {
+		#[automatically_derived]
 		impl<T, U> ::core::ops::Drop for Test<T, U>
 		where T: ::zeroize::ZeroizeOnDrop
 		{
@@ -82,6 +87,7 @@ fn both() -> Result<()> {
 	};
 	#[cfg(feature = "zeroize-on-drop")]
 	let drop = quote! {
+		#[automatically_derived]
 		impl<T, U> ::core::ops::Drop for Test<T, U>
 		where T: ::zeroize::ZeroizeOnDrop
 		{
@@ -98,6 +104,7 @@ fn both() -> Result<()> {
 			}
 		}
 
+		#[automatically_derived]
 		impl<T, U> ::zeroize::ZeroizeOnDrop for Test<T, U>
 		where T: ::zeroize::ZeroizeOnDrop
 		{ }
@@ -109,6 +116,7 @@ fn both() -> Result<()> {
 			struct Test<T, U>(T, std::marker::PhantomData<U>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T, U> ::zeroize::Zeroize for Test<T, U>
 			where T: ::zeroize::Zeroize
 			{
@@ -137,6 +145,7 @@ fn crate_() -> Result<()> {
 			struct Test<T>(T);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> zeroize_::Zeroize for Test<T>
 			where T: zeroize_::Zeroize
 			{
@@ -163,6 +172,7 @@ fn crate_drop() -> Result<()> {
 		},
 		#[cfg(not(feature = "zeroize-on-drop"))]
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::ops::Drop for Test<T>
 			where T: zeroize_::ZeroizeOnDrop
 			{
@@ -173,6 +183,7 @@ fn crate_drop() -> Result<()> {
 		},
 		#[cfg(feature = "zeroize-on-drop")]
 		quote! {
+			#[automatically_derived]
 			impl<T> ::core::ops::Drop for Test<T>
 			where T: zeroize_::ZeroizeOnDrop
 			{
@@ -188,6 +199,7 @@ fn crate_drop() -> Result<()> {
 				}
 			}
 
+			#[automatically_derived]
 			impl<T> zeroize_::ZeroizeOnDrop for Test<T>
 			where T: zeroize_::ZeroizeOnDrop
 			{ }
@@ -203,6 +215,7 @@ fn fqs() -> Result<()> {
 			struct Test<T>(#[derive_where(Zeroize(fqs))] std::marker::PhantomData<T>);
 		},
 		quote! {
+			#[automatically_derived]
 			impl<T> ::zeroize::Zeroize for Test<T> {
 				fn zeroize(&mut self) {
 					use ::zeroize::Zeroize;

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1,0 +1,8 @@
+use std::marker::PhantomData;
+
+use derive_where::derive_where;
+
+/// Test for `clippy::non_canonical_clone_impl`, which should not be triggered
+/// because of `#[automatically_derived]`.
+#[derive_where(Clone, Copy; T: Copy)]
+struct NonCanonicalCloneImpl<T>(PhantomData<T>);

--- a/tests/skip/debug.rs
+++ b/tests/skip/debug.rs
@@ -7,6 +7,7 @@ fn struct_all() {
 	#[derive_where(Debug)]
 	#[derive_where(skip_inner)]
 	struct Test<T> {
+		#[allow(dead_code)]
 		a: Wrapper<T>,
 	}
 
@@ -22,7 +23,9 @@ fn struct_partial() {
 	#[derive_where(Debug)]
 	struct Test<T> {
 		#[derive_where(skip)]
+		#[allow(dead_code)]
 		a: Wrapper<T>,
+		#[allow(dead_code)]
 		b: Wrapper<T>,
 	}
 
@@ -41,6 +44,7 @@ fn variant_all() {
 	#[derive_where(Debug)]
 	enum Test<T> {
 		#[derive_where(skip_inner)]
+		#[allow(dead_code)]
 		A { a: Wrapper<T> },
 	}
 
@@ -57,7 +61,9 @@ fn variant_partial() {
 	enum Test<T> {
 		A {
 			#[derive_where(skip)]
+			#[allow(dead_code)]
 			a: Wrapper<T>,
+			#[allow(dead_code)]
 			b: Wrapper<T>,
 		},
 	}


### PR DESCRIPTION
Fixes #91.

My understanding is that we should have done this all along anyway.
See the [Rust reference](https://doc.rust-lang.org/1.74.0/reference/attributes/derive.html?highlight=%23%5Bautomatically_derived%5D#the-automatically_derived-attribute).