### PR TITLE
Use optimized output for `Clone` and `PartialOrd` with custom bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Use the `Copy` implementation for `Clone` and the `Ord` implementation for
+  `PartialOrd` when custom bounds are present.
+
 ## [1.2.7] - 2023-12-14
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,7 +636,7 @@ fn generate_impl(
 	let mut where_clause = where_clause.map(Cow::Borrowed);
 	derive_where.where_clause(&mut where_clause, trait_, item);
 
-	let body = generate_body(derive_where, &derive_where.traits, trait_, item, generics);
+	let body = generate_body(derive_where, trait_, item, generics);
 
 	let ident = item.ident();
 	let path = trait_.impl_path(trait_);
@@ -666,25 +666,22 @@ fn generate_impl(
 /// Generate implementation method body for a [`Trait`].
 fn generate_body(
 	derive_where: &DeriveWhere,
-	traits: &[DeriveTrait],
 	trait_: &DeriveTrait,
 	item: &Item,
 	generics: &SplitGenerics<'_>,
 ) -> TokenStream {
-	let any_bound = !derive_where.generics.is_empty();
-
 	match &item {
 		Item::Item(data) => {
-			let body = trait_.build_body(any_bound, traits, trait_, data);
-			trait_.build_signature(any_bound, item, generics, traits, trait_, &body)
+			let body = trait_.build_body(derive_where, trait_, data);
+			trait_.build_signature(derive_where, item, generics, trait_, &body)
 		}
 		Item::Enum { variants, .. } => {
 			let body: TokenStream = variants
 				.iter()
-				.map(|data| trait_.build_body(any_bound, traits, trait_, data))
+				.map(|data| trait_.build_body(derive_where, trait_, data))
 				.collect();
 
-			trait_.build_signature(any_bound, item, generics, traits, trait_, &body)
+			trait_.build_signature(derive_where, item, generics, trait_, &body)
 		}
 	}
 }

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -7,7 +7,7 @@ use super::test_derive;
 fn bound() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Clone; T)]
+			#[derive_where(Clone, Copy; T)]
 			struct Test<T, U>(T, std::marker::PhantomData<U>);
 		},
 		quote! {
@@ -22,6 +22,11 @@ fn bound() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
+			impl<T, U> ::core::marker::Copy for Test<T, U>
+			where T: ::core::marker::Copy
+			{ }
 		},
 	)
 }
@@ -30,7 +35,7 @@ fn bound() -> Result<()> {
 fn bound_multiple() -> Result<()> {
 	test_derive(
 		quote! {
-			#[derive_where(Clone; T, U)]
+			#[derive_where(Clone, Copy; T, U)]
 			struct Test<T, U, V>((T, U), std::marker::PhantomData<V>);
 		},
 		quote! {
@@ -47,6 +52,13 @@ fn bound_multiple() -> Result<()> {
 					}
 				}
 			}
+
+			#[automatically_derived]
+			impl<T, U, V> ::core::marker::Copy for Test<T, U, V>
+			where
+				T: ::core::marker::Copy,
+				U: ::core::marker::Copy
+			{ }
 		},
 	)
 }

--- a/src/test/clone.rs
+++ b/src/test/clone.rs
@@ -95,8 +95,59 @@ fn union_() -> Result<()> {
 				fn clone(&self) -> Self {
 					struct __AssertCopy<__T: ::core::marker::Copy + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
 					let _: __AssertCopy<Self>;
+					*self
 				}
 			}
+		},
+	)
+}
+
+#[test]
+fn no_bound() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone, Copy)]
+			struct Test<T>(std::marker::PhantomData<T>);
+		},
+		quote! {
+			#[automatically_derived]
+			impl<T> ::core::clone::Clone for Test<T>
+			{
+				#[inline]
+				fn clone(&self) -> Self {
+					*self
+				}
+			}
+
+			#[automatically_derived]
+			impl<T> ::core::marker::Copy for Test<T>
+			{ }
+		},
+	)
+}
+
+#[test]
+fn custom_bound() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone, Copy; T: Trait)]
+			struct Test<T>(T);
+		},
+		quote! {
+			#[automatically_derived]
+			impl<T> ::core::clone::Clone for Test<T>
+			where T: Trait
+			{
+				#[inline]
+				fn clone(&self) -> Self {
+					*self
+				}
+			}
+
+			#[automatically_derived]
+			impl<T> ::core::marker::Copy for Test<T>
+			where T: Trait
+			{ }
 		},
 	)
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,5 +1,6 @@
 mod basic;
 mod bound;
+mod clone;
 mod discriminant;
 mod enum_;
 #[cfg(not(any(feature = "nightly", feature = "safe")))]

--- a/src/test/partial_ord.rs
+++ b/src/test/partial_ord.rs
@@ -200,3 +200,73 @@ fn bound() -> Result<()> {
 		},
 	)
 }
+
+#[test]
+fn no_bound() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Ord, PartialOrd)]
+			struct Test<T>(std::marker::PhantomData<T>);
+		},
+		quote! {
+			#[automatically_derived]
+			impl<T> ::core::cmp::Ord for Test<T> {
+				#[inline]
+				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
+					match (self, __other) {
+						(Test(ref __field_0), Test(ref __other_field_0)) =>
+							match ::core::cmp::Ord::cmp(__field_0, __other_field_0) {
+								::core::cmp::Ordering::Equal => ::core::cmp::Ordering::Equal,
+								__cmp => __cmp,
+							},
+					}
+				}
+			}
+
+			#[automatically_derived]
+			impl<T> ::core::cmp::PartialOrd for Test<T> {
+				#[inline]
+				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+					::core::option::Option::Some(::core::cmp::Ord::cmp(self, __other))
+				}
+			}
+		},
+	)
+}
+
+#[test]
+fn custom_bound() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Ord, PartialOrd; T: TestTrait)]
+			struct Test<T>(std::marker::PhantomData<T>);
+		},
+		quote! {
+			#[automatically_derived]
+			impl<T> ::core::cmp::Ord for Test<T>
+			where T: TestTrait
+			{
+				#[inline]
+				fn cmp(&self, __other: &Self) -> ::core::cmp::Ordering {
+					match (self, __other) {
+						(Test(ref __field_0), Test(ref __other_field_0)) =>
+							match ::core::cmp::Ord::cmp(__field_0, __other_field_0) {
+								::core::cmp::Ordering::Equal => ::core::cmp::Ordering::Equal,
+								__cmp => __cmp,
+							},
+					}
+				}
+			}
+
+			#[automatically_derived]
+			impl<T> ::core::cmp::PartialOrd for Test<T>
+			where T: TestTrait
+			{
+				#[inline]
+				fn partial_cmp(&self, __other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+					::core::option::Option::Some(::core::cmp::Ord::cmp(self, __other))
+				}
+			}
+		},
+	)
+}

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -18,7 +18,7 @@ mod zeroize_on_drop;
 use proc_macro2::{Span, TokenStream};
 use syn::{punctuated::Punctuated, spanned::Spanned, Meta, Path, Result, Token, TypeParamBound};
 
-use crate::{Data, DeriveTrait, Error, Item, SplitGenerics};
+use crate::{Data, DeriveTrait, DeriveWhere, Error, Item, SplitGenerics};
 
 /// Type implementing [`TraitImpl`] for every trait.
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -133,26 +133,23 @@ impl TraitImpl for Trait {
 
 	fn build_signature(
 		&self,
-		any_bound: bool,
+		derive_where: &DeriveWhere,
 		item: &Item,
 		generics: &SplitGenerics<'_>,
-		traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
 		self.implementation()
-			.build_signature(any_bound, item, generics, traits, trait_, body)
+			.build_signature(derive_where, item, generics, trait_, body)
 	}
 
 	fn build_body(
 		&self,
-		any_bound: bool,
-		traits: &[DeriveTrait],
+		derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {
-		self.implementation()
-			.build_body(any_bound, traits, trait_, data)
+		self.implementation().build_body(derive_where, trait_, data)
 	}
 }
 
@@ -199,10 +196,9 @@ pub trait TraitImpl {
 	/// Build method signature for this [`Trait`].
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		_item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		_body: &TokenStream,
 	) -> TokenStream {
@@ -212,8 +208,7 @@ pub trait TraitImpl {
 	/// Build method body for this [`Trait`].
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		_trait_: &DeriveTrait,
 		_data: &Data,
 	) -> TokenStream {

--- a/src/trait_/common_ord.rs
+++ b/src/trait_/common_ord.rs
@@ -14,13 +14,13 @@ use syn::{parse_quote, Expr, ExprLit, LitInt, Path};
 
 #[cfg(not(feature = "nightly"))]
 use crate::{item::Representation, Discriminant, Trait};
-use crate::{Data, DeriveTrait, Item, SimpleType, SplitGenerics};
+use crate::{Data, DeriveTrait, DeriveWhere, Item, SimpleType, SplitGenerics};
 
 /// Build signature for [`PartialOrd`] and [`Ord`].
 pub fn build_ord_signature(
 	item: &Item,
 	#[cfg_attr(feature = "nightly", allow(unused_variables))] generics: &SplitGenerics<'_>,
-	#[cfg_attr(feature = "nightly", allow(unused_variables))] traits: &[DeriveTrait],
+	#[cfg_attr(feature = "nightly", allow(unused_variables))] derive_where: &DeriveWhere,
 	trait_: &DeriveTrait,
 	body: &TokenStream,
 ) -> TokenStream {
@@ -173,13 +173,13 @@ pub fn build_ord_signature(
 								}
 							});
 
-							if traits.iter().any(|trait_| trait_ == Trait::Copy) {
+							if derive_where.contains(Trait::Copy) {
 								quote! {
 									#validate
 
 									#path::#method(&(*self as isize), &(*__other as isize))
 								}
-							} else if traits.iter().any(|trait_| trait_ == Trait::Clone) {
+							} else if derive_where.contains(Trait::Clone) {
 								let clone = DeriveTrait::Clone.path();
 								quote! {
 									#validate
@@ -215,11 +215,11 @@ pub fn build_ord_signature(
 							)
 						}
 						Discriminant::UnitRepr(repr) => {
-							if traits.iter().any(|trait_| trait_ == Trait::Copy) {
+							if derive_where.contains(Trait::Copy) {
 								quote! {
 									#path::#method(&(*self as #repr), &(*__other as #repr))
 								}
-							} else if traits.iter().any(|trait_| trait_ == Trait::Clone) {
+							} else if derive_where.contains(Trait::Clone) {
 								let clone = DeriveTrait::Clone.path();
 								quote! {
 									#path::#method(&(#clone::clone(self) as #repr), &(#clone::clone(__other) as #repr))

--- a/src/trait_/debug.rs
+++ b/src/trait_/debug.rs
@@ -3,7 +3,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::{Data, DeriveTrait, Item, SimpleType, SplitGenerics, TraitImpl};
+use crate::{Data, DeriveTrait, DeriveWhere, Item, SimpleType, SplitGenerics, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
 /// [`Debug`](trait@std::fmt::Debug).
@@ -20,10 +20,9 @@ impl TraitImpl for Debug {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		_item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -38,8 +37,7 @@ impl TraitImpl for Debug {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {

--- a/src/trait_/default.rs
+++ b/src/trait_/default.rs
@@ -3,7 +3,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::{Data, DeriveTrait, Item, SimpleType, SplitGenerics, TraitImpl};
+use crate::{Data, DeriveTrait, DeriveWhere, Item, SimpleType, SplitGenerics, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
 /// [`Default`](trait@std::default::Default).
@@ -20,10 +20,9 @@ impl TraitImpl for Default {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		_item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -36,8 +35,7 @@ impl TraitImpl for Default {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {

--- a/src/trait_/eq.rs
+++ b/src/trait_/eq.rs
@@ -3,7 +3,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::{Data, DeriveTrait, Item, SplitGenerics, TraitImpl};
+use crate::{Data, DeriveTrait, DeriveWhere, Item, SplitGenerics, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
 /// [`Eq`](trait@std::cmp::Eq).
@@ -20,10 +20,9 @@ impl TraitImpl for Eq {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		_item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -39,8 +38,7 @@ impl TraitImpl for Eq {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {

--- a/src/trait_/hash.rs
+++ b/src/trait_/hash.rs
@@ -3,7 +3,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::{Data, DataType, DeriveTrait, Item, SimpleType, SplitGenerics, TraitImpl};
+use crate::{Data, DataType, DeriveTrait, DeriveWhere, Item, SimpleType, SplitGenerics, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
 /// [`Hash`](trait@std::hash::Hash).
@@ -20,10 +20,9 @@ impl TraitImpl for Hash {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		_item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -38,8 +37,7 @@ impl TraitImpl for Hash {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {

--- a/src/trait_/ord.rs
+++ b/src/trait_/ord.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::common_ord;
-use crate::{Data, DeriveTrait, Item, SimpleType, SplitGenerics, TraitImpl};
+use crate::{Data, DeriveTrait, DeriveWhere, Item, SimpleType, SplitGenerics, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
 /// [`Ord`](trait@std::cmp::Ord).
@@ -21,14 +21,13 @@ impl TraitImpl for Ord {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		derive_where: &DeriveWhere,
 		item: &Item,
 		generics: &SplitGenerics<'_>,
-		traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
-		let body = common_ord::build_ord_signature(item, generics, traits, trait_, body);
+		let body = common_ord::build_ord_signature(item, generics, derive_where, trait_, body);
 
 		quote! {
 			#[inline]
@@ -40,8 +39,7 @@ impl TraitImpl for Ord {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {

--- a/src/trait_/partial_eq.rs
+++ b/src/trait_/partial_eq.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::common_ord::build_incomparable_pattern;
-use crate::{Data, DeriveTrait, Item, SimpleType, SplitGenerics, TraitImpl};
+use crate::{Data, DeriveTrait, DeriveWhere, Item, SimpleType, SplitGenerics, TraitImpl};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for
 /// [`PartialEq`](trait@std::cmp::PartialEq).
@@ -21,10 +21,9 @@ impl TraitImpl for PartialEq {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -107,8 +106,7 @@ impl TraitImpl for PartialEq {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {

--- a/src/trait_/zeroize.rs
+++ b/src/trait_/zeroize.rs
@@ -7,7 +7,9 @@ use syn::{
 	Token,
 };
 
-use crate::{util, Data, DeriveTrait, Error, Item, SimpleType, SplitGenerics, TraitImpl};
+use crate::{
+	util, Data, DeriveTrait, DeriveWhere, Error, Item, SimpleType, SplitGenerics, TraitImpl,
+};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) .
 pub struct Zeroize;
@@ -79,10 +81,9 @@ impl TraitImpl for Zeroize {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -107,8 +108,7 @@ impl TraitImpl for Zeroize {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {

--- a/src/trait_/zeroize_on_drop.rs
+++ b/src/trait_/zeroize_on_drop.rs
@@ -7,7 +7,9 @@ use syn::{
 	Token,
 };
 
-use crate::{util, Data, DeriveTrait, Error, Item, SimpleType, SplitGenerics, TraitImpl};
+use crate::{
+	util, Data, DeriveTrait, DeriveWhere, Error, Item, SimpleType, SplitGenerics, TraitImpl,
+};
 
 /// Dummy-struct implement [`Trait`](crate::Trait) for [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html) .
 pub struct ZeroizeOnDrop;
@@ -85,10 +87,9 @@ impl TraitImpl for ZeroizeOnDrop {
 
 	fn build_signature(
 		&self,
-		_any_bound: bool,
+		_derive_where: &DeriveWhere,
 		item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_traits: &[DeriveTrait],
 		trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
@@ -135,8 +136,7 @@ impl TraitImpl for ZeroizeOnDrop {
 
 	fn build_body(
 		&self,
-		_any_bound: bool,
-		_traits: &[DeriveTrait],
+		_derive_where: &DeriveWhere,
 		trait_: &DeriveTrait,
 		data: &Data,
 	) -> TokenStream {


### PR DESCRIPTION
Some more `Clone` and `PartialOrd` optimization.
Thank you @eric-seppanen for pointing it out.