### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,11 @@ jobs:
         run: |
           rustup toolchain install ${{ matrix.rust }} --profile minimal --allow-downgrade
           rustup default ${{ matrix.rust }}
-      - name: Pin `zeroize` for MSRV
+      - name: Pin dependencies for MSRV
         if: matrix.msrv
-        run:
+        run: |
           cargo update -p zeroize --precise 1.6.0
+          cargo update -p pretty_assertions --precise 1.4.0
       - name: Build
         run:
           cargo build --workspace ${{ matrix.features }}
@@ -107,10 +108,11 @@ jobs:
         run: |
           rustup toolchain install ${{ matrix.rust }} --target thumbv6m-none-eabi --profile minimal --allow-downgrade
           rustup default ${{ matrix.rust }}
-      - name: Pin `zeroize` for MSRV
+      - name: Pin dependencies for MSRV
         if: matrix.msrv
-        run:
+        run: |
           cargo update -p zeroize --precise 1.6.0
+          cargo update -p pretty_assertions --precise 1.4.0
       - name: Build
         run:
           cargo build --target thumbv6m-none-eabi ${{ matrix.features }} -p ensure-no-std

--- a/test-crates/minimal-versions/Cargo.toml
+++ b/test-crates/minimal-versions/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 edition = "2021"
 name = "minimal-versions"
 publish = false
+rust-version = "1.57"
 version = "0.0.0"
 
 [features]


### PR DESCRIPTION
The newest version of `pretty_assertions` breaks our MSRV, so we had to downgrade in the CI.
Adding the `rust-version` to the `minimal-versions` crate fixed that `cargo +nightly update -Z minimal-versions` was generating a lockfile that is incompatible with Rust v1.57.