### PR TITLE
Feat: Allow lifetime for bounds in non-binded generic params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 - Allow lifetime `for<'a, ...>` bounds in non-bounded generic parameters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow lifetime `for<'a, ...>` bounds in non-bounded generic parameters.
 
 ### Changed
 - Use the `Copy` implementation for `Clone` and the `Ord` implementation for

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -299,8 +299,8 @@ impl DeriveWhere {
 	}
 }
 
-/// Holds the first part of a [`PredicateType`] prior to the `:`. Optionally contains lifetime `for`
-/// bindings.
+/// Holds the first part of a [`PredicateType`] prior to the `:`. Optionally
+/// contains lifetime `for` bindings.
 #[derive(Eq, PartialEq)]
 pub struct GenericNoBound {
 	/// Any `for<'a, 'b, 'etc>` bindings for the type.
@@ -318,12 +318,14 @@ impl Parse for GenericNoBound {
 	}
 }
 
-/// Holds a single generic [type](GenericNoBound) with optional lifetime bounds or [type with bound](PredicateType).
+/// Holds a single generic [type](GenericNoBound) with optional lifetime bounds
+/// or [type with bound](PredicateType).
 #[derive(Eq, PartialEq)]
 pub enum Generic {
 	/// Generic type with custom [specified bounds](PredicateType).
 	CustomBound(PredicateType),
-	/// Generic [type](GenericNoBound) which will be bound to the [`DeriveTrait`].
+	/// Generic [type](GenericNoBound) which will be bound to the
+	/// [`DeriveTrait`].
 	NoBound(GenericNoBound),
 }
 
@@ -332,8 +334,8 @@ impl Parse for Generic {
 		let fork = input.fork();
 
 		// Try to parse input as a `WherePredicate`. The problem is, both expressions
-		// start with an optional lifetime for bound and then Type, so starting with the `WherePredicate` is the easiest way
-		// of differentiating them.
+		// start with an optional lifetime for bound and then Type, so starting with the
+		// `WherePredicate` is the easiest way of differentiating them.
 		if let Ok(where_predicate) = WherePredicate::parse(&fork) {
 			input.advance_to(&fork);
 

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -300,6 +300,7 @@ impl DeriveWhere {
 /// bindings.
 #[derive(Eq, PartialEq)]
 pub struct GenericNoBound(Option<BoundLifetimes>, Type);
+
 impl Parse for GenericNoBound {
 	fn parse(input: ParseStream) -> Result<Self> {
 		Ok(Self(input.parse()?, input.parse()?))

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -112,6 +112,31 @@ fn where_() -> Result<()> {
 }
 
 #[test]
+fn for_lifetime() -> Result<()> {
+	test_derive(
+		quote! {
+			#[derive_where(Clone; for<'a> T)]
+			struct Test<T, U>(T, std::marker::PhantomData<U>) where T: std::fmt::Debug;
+		},
+		quote! {
+			#[automatically_derived]
+			impl<T, U> ::core::clone::Clone for Test<T, U>
+			where
+				T: std::fmt::Debug,
+				for<'a> T: ::core::clone::Clone
+			{
+				#[inline]
+				fn clone(&self) -> Self {
+					match self {
+						Test(ref __field_0, ref __field_1) => Test(::core::clone::Clone::clone(__field_0), ::core::clone::Clone::clone(__field_1)),
+					}
+				}
+			}
+		},
+	)
+}
+
+#[test]
 fn associated_type() -> Result<()> {
 	test_derive(
 		quote! {


### PR DESCRIPTION
It's currently not possible to use higher rank trait bounds without providing custom predicate type bounds. Our particular use case is enabling "trivial bounds" without requiring the nightly feature. For context: https://github.com/rust-lang/rust/issues/48214#issuecomment-2799836786

For example:

```rust
// fails due to "the trait bound `std::string::String: std::marker::Copy` is not satisfied"
#[derive_where(Clone, Copy; String)]
struct TestThing {
    a: String,
}

// Compiles! Copy is just not implemented due to String obviously not being copy, so it would compile error on use.
#[derive_where(Clone, Copy; for<'a> String)]
struct TestThing {
    a: String,
}
```

This is useful for adding perfect derives to macro-generated structs. 

I'm not fully sure whether having a HRTB should make `has_type_param` return false or not. I think its probably fine to keep it returning true since adding one that's not used doesn't change the behavior; it should still be derivable w/ the standard derive. Users can always make type aliases to get around this anyways if they disagree lol.