### PR TITLE
Support skipping only some variants with `ZeroizeOnDrop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use the `Copy` implementation for `Clone` and the `Ord` implementation for
   `PartialOrd` when custom bounds are present.
 
+### Fixed
+- Support skipping only some variants with `ZeroizeOnDrop`.
+- Only generate single call to `zeroize()` with `ZeroizeOnDrop` on multiple
+  fields or variants.
+
 ## [1.2.7] - 2023-12-14
 
 ### Fixed


### PR DESCRIPTION
I noticed that the following would fail to compile:
```rust
#[derive_where(ZeroizeOnDrop)]
enum Test<T> {
    A(PhantomData<T>),
    #[derive_where(skip_inner)]
    B(PhantomData<T>),
}
```
Because it produces the following:
```rust
impl<T> Drop for Test<T> {
    fn drop(&mut self) {
        match self {
            Test::A(ref mut __field_0) => {
                __field_0.zeroize_or_on_drop();
            }
        }
    }
}
```
Instead, we now make sure to also cover variants that are skipped, but their body is just empty now.

See the test I added for a more complete example.