### PR TITLE
Implement `ZeroizeOnDrop` without `Drop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `no_drop` item-level option to `ZeroizeOnDrop` which does not implement
+  `Drop` but instead only asserts that every field implements `ZeroizeOnDrop`.
+
 ## [1.4.0] - 2025-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ and can be implemented without [`Zeroize`], otherwise it only implements
 - `crate`: an item-level option which specifies a path to the [`zeroize`]
   crate in case of a re-export or rename.
 - `no_drop`: an item-level option which will not implement [`Drop`] but instead
-  only assert that every field implements [`ZeroizeOnDrop`].
+  only assert that every field implements [`ZeroizeOnDrop`]. Requires the
+  `zeroize-on-drop` feature.
 
 ```rust
 #[derive_where(ZeroizeOnDrop(crate = zeroize_))]

--- a/README.md
+++ b/README.md
@@ -238,9 +238,11 @@ If the `zeroize-on-drop` feature is enabled, it implements [`ZeroizeOnDrop`]
 and can be implemented without [`Zeroize`], otherwise it only implements
 [`Drop`] and requires [`Zeroize`] to be implemented.
 
-[`ZeroizeOnDrop`] has one option:
+[`ZeroizeOnDrop`] has two options:
 - `crate`: an item-level option which specifies a path to the [`zeroize`]
   crate in case of a re-export or rename.
+- `no_drop`: an item-level option which will not implement [`Drop`] but instead
+  only assert that every field implements [`ZeroizeOnDrop`].
 
 ```rust
 #[derive_where(ZeroizeOnDrop(crate = zeroize_))]

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -15,7 +15,7 @@ pub use self::{
 	default::Default,
 	field::FieldAttr,
 	incomparable::Incomparable,
-	item::{DeriveTrait, DeriveWhere, ItemAttr},
+	item::{DeriveWhere, ItemAttr},
 	skip::{Skip, SkipGroup},
 	variant::VariantAttr,
 };

--- a/src/attr/field.rs
+++ b/src/attr/field.rs
@@ -4,7 +4,7 @@ use syn::{spanned::Spanned, Attribute, Meta, Result};
 
 use crate::{util::MetaListExt, DeriveWhere, Error, Skip, DERIVE_WHERE};
 #[cfg(feature = "zeroize")]
-use crate::{Trait, TraitImpl, ZeroizeFqs};
+use crate::{Trait, ZeroizeFqs};
 
 /// Attributes on field.
 #[derive(Default)]

--- a/src/attr/incomparable.rs
+++ b/src/attr/incomparable.rs
@@ -3,7 +3,7 @@
 use proc_macro2::Span;
 use syn::{spanned::Spanned, Meta, Result};
 
-use crate::{attr::DeriveTrait, DeriveWhere, Error};
+use crate::{trait_::DeriveTrait, DeriveWhere, Error};
 
 /// Stores if this variant should be incomparable when implementing
 /// [`PartialEq`] or [`PartialOrd`].

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -1,20 +1,17 @@
 //! [`Attribute`] parsing for items.
 
-use std::{borrow::Cow, ops::Deref};
+use std::borrow::Cow;
 
 use proc_macro2::Span;
 use syn::{
 	parse::{discouraged::Speculative, Parse, ParseStream},
 	punctuated::Punctuated,
 	spanned::Spanned,
-	Attribute, BoundLifetimes, Data, Ident, Meta, Path, PredicateType, Result, Token, TraitBound,
-	TraitBoundModifier, Type, TypeParamBound, TypePath, WhereClause, WherePredicate,
+	Attribute, BoundLifetimes, Data, Ident, Meta, PredicateType, Result, Token, Type, TypePath,
+	WhereClause, WherePredicate,
 };
 
-use crate::{
-	util::{self, MetaListExt},
-	Error, Incomparable, Item, Skip, SkipGroup, Trait, TraitImpl, DERIVE_WHERE,
-};
+use crate::{trait_::DeriveTrait, Error, Incomparable, Item, Skip, SkipGroup, Trait, DERIVE_WHERE};
 
 /// Attributes on item.
 #[derive(Default)]
@@ -259,7 +256,7 @@ impl DeriveWhere {
 	pub fn any_skip(&self) -> bool {
 		self.traits
 			.iter()
-			.any(|trait_| SkipGroup::trait_supported_by_skip_all(**trait_))
+			.any(|trait_| SkipGroup::trait_supported_by_skip_all(***trait_))
 	}
 
 	/// Create [`WhereClause`] for the given parameters.
@@ -350,177 +347,6 @@ impl Parse for Generic {
 				Ok(no_bound) => Ok(Generic::NoBound(no_bound)),
 				Err(error) => Err(Error::generic_syntax(error.span(), error)),
 			}
-		}
-	}
-}
-
-/// Trait to implement.
-#[derive(Eq, PartialEq)]
-pub enum DeriveTrait {
-	/// [`Clone`].
-	Clone,
-	/// [`Copy`].
-	Copy,
-	/// [`Debug`](std::fmt::Debug).
-	Debug,
-	/// [`Default`].
-	Default,
-	/// [`Eq`].
-	Eq,
-	/// [`Hash`](std::hash::Hash).
-	Hash,
-	/// [`Ord`].
-	Ord,
-	/// [`PartialEq`].
-	PartialEq,
-	/// [`PartialOrd`].
-	PartialOrd,
-	/// [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html).
-	#[cfg(feature = "zeroize")]
-	Zeroize {
-		/// [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) path.
-		crate_: Option<Path>,
-	},
-	/// [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html).
-	#[cfg(feature = "zeroize")]
-	ZeroizeOnDrop {
-		/// [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html) path.
-		crate_: Option<Path>,
-		/// If `Drop` should be implemented.
-		no_drop: bool,
-	},
-}
-
-impl Deref for DeriveTrait {
-	type Target = Trait;
-
-	fn deref(&self) -> &Self::Target {
-		use DeriveTrait::*;
-
-		match self {
-			Clone => &Trait::Clone,
-			Copy => &Trait::Copy,
-			Debug => &Trait::Debug,
-			Default => &Trait::Default,
-			Eq => &Trait::Eq,
-			Hash => &Trait::Hash,
-			Ord => &Trait::Ord,
-			PartialEq => &Trait::PartialEq,
-			PartialOrd => &Trait::PartialOrd,
-			#[cfg(feature = "zeroize")]
-			Zeroize { .. } => &Trait::Zeroize,
-			#[cfg(feature = "zeroize")]
-			ZeroizeOnDrop { .. } => &Trait::ZeroizeOnDrop,
-		}
-	}
-}
-
-impl PartialEq<Trait> for &DeriveTrait {
-	fn eq(&self, other: &Trait) -> bool {
-		let trait_: &Trait = self;
-		trait_ == other
-	}
-}
-
-impl DeriveTrait {
-	/// Returns fully qualified [`Path`] for this trait.
-	pub fn path(&self) -> Path {
-		use DeriveTrait::*;
-
-		match self {
-			Clone => util::path_from_root_and_strs(self.crate_(), &["clone", "Clone"]),
-			Copy => util::path_from_root_and_strs(self.crate_(), &["marker", "Copy"]),
-			Debug => util::path_from_root_and_strs(self.crate_(), &["fmt", "Debug"]),
-			Default => util::path_from_root_and_strs(self.crate_(), &["default", "Default"]),
-			Eq => util::path_from_root_and_strs(self.crate_(), &["cmp", "Eq"]),
-			Hash => util::path_from_root_and_strs(self.crate_(), &["hash", "Hash"]),
-			Ord => util::path_from_root_and_strs(self.crate_(), &["cmp", "Ord"]),
-			PartialEq => util::path_from_root_and_strs(self.crate_(), &["cmp", "PartialEq"]),
-			PartialOrd => util::path_from_root_and_strs(self.crate_(), &["cmp", "PartialOrd"]),
-			#[cfg(feature = "zeroize")]
-			Zeroize { .. } => util::path_from_root_and_strs(self.crate_(), &["Zeroize"]),
-			#[cfg(feature = "zeroize")]
-			ZeroizeOnDrop { .. } => util::path_from_root_and_strs(self.crate_(), &["ZeroizeOnDrop"]),
-		}
-	}
-
-	/// Returns the path to the root crate for this trait.
-	pub fn crate_(&self) -> Path {
-		use DeriveTrait::*;
-
-		match self {
-			Clone => util::path_from_strs(&["core"]),
-			Copy => util::path_from_strs(&["core"]),
-			Debug => util::path_from_strs(&["core"]),
-			Default => util::path_from_strs(&["core"]),
-			Eq => util::path_from_strs(&["core"]),
-			Hash => util::path_from_strs(&["core"]),
-			Ord => util::path_from_strs(&["core"]),
-			PartialEq => util::path_from_strs(&["core"]),
-			PartialOrd => util::path_from_strs(&["core"]),
-			#[cfg(feature = "zeroize")]
-			Zeroize { crate_, .. } => {
-				if let Some(crate_) = crate_ {
-					crate_.clone()
-				} else {
-					util::path_from_strs(&["zeroize"])
-				}
-			}
-			#[cfg(feature = "zeroize")]
-			ZeroizeOnDrop { crate_, .. } => {
-				if let Some(crate_) = crate_ {
-					crate_.clone()
-				} else {
-					util::path_from_strs(&["zeroize"])
-				}
-			}
-		}
-	}
-
-	/// Returns where-clause bounds for the trait in respect of the item type.
-	fn where_bounds(&self, data: &Item) -> Punctuated<TypeParamBound, Token![+]> {
-		let mut list = Punctuated::new();
-
-		list.push(TypeParamBound::Trait(TraitBound {
-			paren_token: None,
-			modifier: TraitBoundModifier::None,
-			lifetimes: None,
-			path: self.path(),
-		}));
-
-		// Add bounds specific to the trait.
-		if let Some(bound) = self.additional_where_bounds(data) {
-			list.push(bound)
-		}
-
-		list
-	}
-
-	/// Create [`DeriveTrait`] from [`ParseStream`].
-	fn from_stream(span: Span, data: &Data, input: ParseStream) -> Result<(Span, Self)> {
-		match Meta::parse(input) {
-			Ok(meta) => {
-				let trait_ = Trait::from_path(meta.path())?;
-
-				if let Data::Union(_) = data {
-					// Make sure this `Trait` supports unions.
-					if !trait_.supports_union() {
-						return Err(Error::union(span));
-					}
-				}
-
-				match &meta {
-					Meta::Path(path) => Ok((path.span(), trait_.default_derive_trait())),
-					Meta::List(list) => {
-						let nested = list.parse_non_empty_nested_metas()?;
-
-						// This will return an error if no options are supported.
-						Ok((list.span(), trait_.parse_derive_trait(meta.span(), nested)?))
-					}
-					Meta::NameValue(name_value) => Err(Error::option_syntax(name_value.span())),
-				}
-			}
-			Err(error) => Err(Error::trait_syntax(error.span())),
 		}
 	}
 }

--- a/src/attr/item.rs
+++ b/src/attr/item.rs
@@ -386,6 +386,8 @@ pub enum DeriveTrait {
 	ZeroizeOnDrop {
 		/// [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html) path.
 		crate_: Option<Path>,
+		/// If `Drop` should be implemented.
+		no_drop: bool,
 	},
 }
 

--- a/src/attr/skip.rs
+++ b/src/attr/skip.rs
@@ -4,7 +4,7 @@ use std::default::Default;
 
 use syn::{spanned::Spanned, Meta, Path, Result};
 
-use crate::{attr::DeriveTrait, util::MetaListExt, DeriveWhere, Error, Trait};
+use crate::{trait_::DeriveTrait, util::MetaListExt, DeriveWhere, Error, Trait};
 
 /// Stores what [`Trait`]s to skip this field or variant for.
 #[cfg_attr(test, derive(Debug))]

--- a/src/attr/zeroize_fqs.rs
+++ b/src/attr/zeroize_fqs.rs
@@ -2,7 +2,7 @@
 
 use syn::{spanned::Spanned, Meta, Result};
 
-use crate::{util::MetaListExt, DeriveWhere, Error, Trait, TraitImpl};
+use crate::{util::MetaListExt, DeriveWhere, Error, Trait};
 
 /// Stores if this field should use FQS to call [`Zeroize::zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html#tymethod.zeroize).
 #[derive(Default)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -183,8 +183,16 @@ impl<'a> Input<'a> {
 				{
 					// `Zeroize(crate = ..)` or `ZeroizeOnDrop(crate = ..)` is used.
 					if let DeriveTrait::Zeroize { crate_: Some(_) }
-					| DeriveTrait::ZeroizeOnDrop { crate_: Some(_) } = *trait_
+					| DeriveTrait::ZeroizeOnDrop {
+						crate_: Some(_), ..
+					} = *trait_
 					{
+						continue;
+					}
+
+					// `ZeroizeOnDrop(no_drop)` is used.
+					#[cfg(feature = "zeroize-on-drop")]
+					if let DeriveTrait::ZeroizeOnDrop { no_drop: true, .. } = *trait_ {
 						continue;
 					}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,7 @@
 //!   crate in case of a re-export or rename.
 //! - `no_drop`: an item-level option which will not implement [`Drop`] but
 //!   instead only assert that every field implements [`ZeroizeOnDrop`].
+//!   Requires the `zeroize-on-drop` feature.
 //!
 //! ```
 //! # #[cfg(feature = "zeroize-on-drop")]
@@ -438,6 +439,7 @@ const DERIVE_WHERE_VISITED: &str = "derive_where_visited";
 ///     trait.
 ///   - `#[derive_where(ZeroizeOnDrop(crate = path))]`: Specify path to
 ///     [`ZeroizeOnDrop`] trait.
+///   - `#[derive_where(ZeroizeOnDrop(no_drop))]`: no [`Drop`] implementation.
 /// - `#[derive_where(skip_inner(EqHashOrd, ..))]`: Skip all fields in the item.
 ///   Optionally specify trait groups to constrain skipping fields. Only works
 ///   for structs, for enums use this on the variant-level.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,9 +272,11 @@
 //! and can be implemented without [`Zeroize`], otherwise it only implements
 //! [`Drop`] and requires [`Zeroize`] to be implemented.
 //!
-//! [`ZeroizeOnDrop`] has one option:
+//! [`ZeroizeOnDrop`] has two options:
 //! - `crate`: an item-level option which specifies a path to the [`zeroize`]
 //!   crate in case of a re-export or rename.
+//! - `no_drop`: an item-level option which will not implement [`Drop`] but
+//!   instead only assert that every field implements [`ZeroizeOnDrop`].
 //!
 //! ```
 //! # #[cfg(feature = "zeroize-on-drop")]
@@ -642,15 +644,7 @@ fn generate_impl(
 	let body = generate_body(derive_where, trait_, item, generics);
 
 	let ident = item.ident();
-	let path = trait_.impl_path(trait_);
-	let mut output = quote! {
-		#[automatically_derived]
-		impl #imp #path for #ident #ty
-		#where_clause
-		{
-			#body
-		}
-	};
+	let mut output = trait_.impl_item(trait_, imp, ident, ty, &where_clause, body);
 
 	if let Some((path, body)) = trait_.additional_impl(trait_) {
 		output.extend(quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,15 +414,12 @@ use self::attr::ZeroizeFqs;
 #[cfg(not(feature = "nightly"))]
 use self::item::Discriminant;
 use self::{
-	attr::{
-		Default, DeriveTrait, DeriveWhere, FieldAttr, Incomparable, ItemAttr, Skip, SkipGroup,
-		VariantAttr,
-	},
+	attr::{Default, DeriveWhere, FieldAttr, Incomparable, ItemAttr, Skip, SkipGroup, VariantAttr},
 	data::{Data, DataType, Field, SimpleType},
 	error::Error,
 	input::Input,
 	item::Item,
-	trait_::{Trait, TraitImpl},
+	trait_::{DeriveTrait, Trait, TraitImpl},
 	util::Either,
 };
 
@@ -644,9 +641,9 @@ fn generate_impl(
 	let body = generate_body(derive_where, trait_, item, generics);
 
 	let ident = item.ident();
-	let mut output = trait_.impl_item(trait_, imp, ident, ty, &where_clause, body);
+	let mut output = trait_.impl_item(imp, ident, ty, &where_clause, body);
 
-	if let Some((path, body)) = trait_.additional_impl(trait_) {
+	if let Some((path, body)) = trait_.additional_impl() {
 		output.extend(quote! {
 			#[automatically_derived]
 			impl #imp #path for #ident #ty
@@ -669,16 +666,16 @@ fn generate_body(
 ) -> TokenStream {
 	match &item {
 		Item::Item(data) => {
-			let body = trait_.build_body(derive_where, trait_, data);
-			trait_.build_signature(derive_where, item, generics, trait_, &body)
+			let body = trait_.build_body(derive_where, data);
+			trait_.build_signature(derive_where, item, generics, &body)
 		}
 		Item::Enum { variants, .. } => {
 			let body: TokenStream = variants
 				.iter()
-				.map(|data| trait_.build_body(derive_where, trait_, data))
+				.map(|data| trait_.build_body(derive_where, data))
 				.collect();
 
-			trait_.build_signature(derive_where, item, generics, trait_, &body)
+			trait_.build_signature(derive_where, item, generics, &body)
 		}
 	}
 }

--- a/src/trait_/copy.rs
+++ b/src/trait_/copy.rs
@@ -1,21 +1,34 @@
 //! [`Copy`](trait@std::marker::Copy) implementation.
 
-use crate::{DeriveTrait, TraitImpl};
+use std::ops::Deref;
 
-/// Dummy-struct implement [`Trait`](crate::Trait) for
-/// [`Copy`](trait@std::marker::Copy).
+use crate::{util, DeriveTrait, Trait, TraitImpl};
+
+/// [`TraitImpl`] for [`Copy`](trait@std::marker::Copy).
 pub struct Copy;
 
 impl TraitImpl for Copy {
-	fn as_str(&self) -> &'static str {
+	fn as_str() -> &'static str {
 		"Copy"
 	}
 
-	fn default_derive_trait(&self) -> DeriveTrait {
+	fn default_derive_trait() -> DeriveTrait {
 		DeriveTrait::Copy
 	}
 
-	fn supports_union(&self) -> bool {
+	fn supports_union() -> bool {
 		true
+	}
+
+	fn path(&self) -> syn::Path {
+		util::path_from_strs(&["core", "marker", "Copy"])
+	}
+}
+
+impl Deref for Copy {
+	type Target = Trait;
+
+	fn deref(&self) -> &Self::Target {
+		&Trait::Copy
 	}
 }

--- a/src/trait_/eq.rs
+++ b/src/trait_/eq.rs
@@ -1,21 +1,26 @@
 //! [`Eq`](trait@std::cmp::Eq) implementation.
 
+use std::ops::Deref;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::{Data, DeriveTrait, DeriveWhere, Item, SplitGenerics, TraitImpl};
+use crate::{util, Data, DeriveTrait, DeriveWhere, Item, SplitGenerics, Trait, TraitImpl};
 
-/// Dummy-struct implement [`Trait`](crate::Trait) for
-/// [`Eq`](trait@std::cmp::Eq).
+/// [`TraitImpl`] for [`Eq`](trait@std::cmp::Eq).
 pub struct Eq;
 
 impl TraitImpl for Eq {
-	fn as_str(&self) -> &'static str {
+	fn as_str() -> &'static str {
 		"Eq"
 	}
 
-	fn default_derive_trait(&self) -> DeriveTrait {
+	fn default_derive_trait() -> DeriveTrait {
 		DeriveTrait::Eq
+	}
+
+	fn path(&self) -> syn::Path {
+		util::path_from_strs(&["core", "cmp", "Eq"])
 	}
 
 	fn build_signature(
@@ -23,7 +28,6 @@ impl TraitImpl for Eq {
 		_derive_where: &DeriveWhere,
 		_item: &Item,
 		_generics: &SplitGenerics<'_>,
-		_trait_: &DeriveTrait,
 		body: &TokenStream,
 	) -> TokenStream {
 		quote! {
@@ -36,16 +40,19 @@ impl TraitImpl for Eq {
 		}
 	}
 
-	fn build_body(
-		&self,
-		_derive_where: &DeriveWhere,
-		trait_: &DeriveTrait,
-		data: &Data,
-	) -> TokenStream {
-		let types = data.iter_fields(**trait_).map(|field| field.type_);
+	fn build_body(&self, _derive_where: &DeriveWhere, data: &Data) -> TokenStream {
+		let types = data.iter_fields(**self).map(|field| field.type_);
 
 		quote! {
 			#(let _: __AssertEq<#types>;)*
 		}
+	}
+}
+
+impl Deref for Eq {
+	type Target = Trait;
+
+	fn deref(&self) -> &Self::Target {
+		&Trait::Eq
 	}
 }

--- a/src/trait_/zeroize_on_drop.rs
+++ b/src/trait_/zeroize_on_drop.rs
@@ -1,17 +1,19 @@
 //! [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html) implementation.
 
+use std::{borrow::Cow, iter};
+
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
-	punctuated::Punctuated, spanned::Spanned, Expr, ExprLit, ExprPath, Lit, Meta, Path, Result,
-	Token,
+	punctuated::Punctuated, spanned::Spanned, Expr, ExprLit, ExprPath, Ident, ImplGenerics, Lit,
+	Meta, Path, Result, Token, TypeGenerics, WhereClause,
 };
 
 use crate::{util, DeriveTrait, DeriveWhere, Error, Item, SplitGenerics, TraitImpl};
 #[cfg(feature = "zeroize-on-drop")]
 use crate::{Data, SimpleType};
 
-/// Dummy-struct implement [`Trait`](crate::Trait) for [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html) .
+/// Dummy-struct implement [`Trait`](crate::Trait) for [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html).
 pub struct ZeroizeOnDrop;
 
 impl TraitImpl for ZeroizeOnDrop {
@@ -20,7 +22,10 @@ impl TraitImpl for ZeroizeOnDrop {
 	}
 
 	fn default_derive_trait(&self) -> DeriveTrait {
-		DeriveTrait::ZeroizeOnDrop { crate_: None }
+		DeriveTrait::ZeroizeOnDrop {
+			crate_: None,
+			no_drop: false,
+		}
 	}
 
 	fn parse_derive_trait(
@@ -32,10 +37,26 @@ impl TraitImpl for ZeroizeOnDrop {
 		debug_assert!(!list.is_empty());
 
 		let mut crate_ = None;
+		#[cfg_attr(not(feature = "zeroize-on-drop"), allow(unused_mut))]
+		let mut no_drop = false;
 
 		for meta in list {
 			match &meta {
-				Meta::Path(path) => return Err(Error::option_trait(path.span(), self.as_str())),
+				Meta::Path(path) => {
+					#[cfg(feature = "zeroize-on-drop")]
+					if path.is_ident("no_drop") {
+						// Check for duplicate `no_drop` option.
+						if !no_drop {
+							no_drop = true;
+						} else {
+							return Err(Error::option_duplicate(path.span(), "no_drop"));
+						}
+
+						continue;
+					}
+
+					return Err(Error::option_trait(path.span(), self.as_str()));
+				}
 				Meta::NameValue(name_value) => {
 					if name_value.path.is_ident("crate") {
 						// Check for duplicate `crate` option.
@@ -70,7 +91,7 @@ impl TraitImpl for ZeroizeOnDrop {
 			}
 		}
 
-		Ok(DeriveTrait::ZeroizeOnDrop { crate_ })
+		Ok(DeriveTrait::ZeroizeOnDrop { crate_, no_drop })
 	}
 
 	#[allow(unused_variables)]
@@ -81,8 +102,56 @@ impl TraitImpl for ZeroizeOnDrop {
 		None
 	}
 
-	fn impl_path(&self, _trait_: &DeriveTrait) -> Path {
-		util::path_from_strs(&["core", "ops", "Drop"])
+	fn impl_item(
+		&self,
+		trait_: &DeriveTrait,
+		imp: &ImplGenerics<'_>,
+		ident: &Ident,
+		ty: &TypeGenerics<'_>,
+		where_clause: &Option<Cow<'_, WhereClause>>,
+		body: TokenStream,
+	) -> TokenStream {
+		let no_drop = if let DeriveTrait::ZeroizeOnDrop { no_drop, .. } = trait_ {
+			*no_drop
+		} else {
+			unreachable!("entered `ZeroizeOnDrop` with another trait")
+		};
+
+		let path = if no_drop {
+			Path {
+				leading_colon: None,
+				segments: Punctuated::from_iter(iter::once(util::path_segment(
+					"DeriveWhereAssertZeroizeOnDrop",
+				))),
+			}
+		} else {
+			util::path_from_strs(&["core", "ops", "Drop"])
+		};
+
+		let imp = quote! {
+			impl #imp #path for #ident #ty
+			#where_clause
+			{
+				#body
+			}
+		};
+
+		if no_drop {
+			quote! {
+				const _: () = {
+					trait DeriveWhereAssertZeroizeOnDrop {
+						fn assert(&mut self);
+					}
+
+					#imp
+				};
+			}
+		} else {
+			quote! {
+				#[automatically_derived]
+				#imp
+			}
+		}
 	}
 
 	fn build_signature(
@@ -99,26 +168,55 @@ impl TraitImpl for ZeroizeOnDrop {
 			},
 			#[cfg(feature = "zeroize-on-drop")]
 			_ => {
-				let crate_ = trait_.crate_();
-				let internal = util::path_segment("__internal");
+				let no_drop = if let DeriveTrait::ZeroizeOnDrop { no_drop, .. } = trait_ {
+					*no_drop
+				} else {
+					unreachable!("entered `ZeroizeOnDrop` with another trait")
+				};
 
-				let mut assert_zeroize = crate_.clone();
-				assert_zeroize
-					.segments
-					.extend([internal.clone(), util::path_segment("AssertZeroize")]);
+				if no_drop {
+					let mut zeroize_on_drop = trait_.crate_();
+					zeroize_on_drop
+						.segments
+						.push(util::path_segment("ZeroizeOnDrop"));
 
-				let mut assert_zeroize_on_drop = crate_;
-				assert_zeroize_on_drop
-					.segments
-					.extend([internal, util::path_segment("AssertZeroizeOnDrop")]);
+					quote! {
+						fn assert(&mut self) {
+							trait AssertZeroizeOnDrop {
+								fn __derive_where_zeroize_on_drop(&mut self);
+							}
 
-				quote! {
-					fn drop(&mut self) {
-						use #assert_zeroize;
-						use #assert_zeroize_on_drop;
+							impl<T: #zeroize_on_drop + ?::core::marker::Sized> AssertZeroizeOnDrop for T {
+								fn __derive_where_zeroize_on_drop(&mut self) {}
+							}
 
-						match self {
-							#body
+							match self {
+								#body
+							}
+						}
+					}
+				} else {
+					let crate_ = trait_.crate_();
+					let internal = util::path_segment("__internal");
+
+					let mut assert_zeroize = crate_.clone();
+					assert_zeroize
+						.segments
+						.extend([internal.clone(), util::path_segment("AssertZeroize")]);
+
+					let mut assert_zeroize_on_drop = crate_;
+					assert_zeroize_on_drop
+						.segments
+						.extend([internal, util::path_segment("AssertZeroizeOnDrop")]);
+
+					quote! {
+						fn drop(&mut self) {
+							use #assert_zeroize;
+							use #assert_zeroize_on_drop;
+
+							match self {
+								#body
+							}
 						}
 					}
 				}
@@ -147,28 +245,40 @@ impl TraitImpl for ZeroizeOnDrop {
 		data: &Data,
 	) -> TokenStream {
 		match data.simple_type() {
+			#[cfg(feature = "zeroize-on-drop")]
 			SimpleType::Struct(fields) | SimpleType::Tuple(fields) => {
-				#[cfg(feature = "zeroize-on-drop")]
-				{
-					let self_pattern = fields.self_pattern_mut();
-					let self_ident = data.iter_self_ident(**trait_);
+				let self_pattern = fields.self_pattern_mut();
+				let self_ident = data.iter_self_ident(**trait_);
 
+				let no_drop = if let DeriveTrait::ZeroizeOnDrop { no_drop, .. } = trait_ {
+					*no_drop
+				} else {
+					unreachable!("entered `ZeroizeOnDrop` with another trait")
+				};
+
+				if no_drop {
+					quote! {
+						#self_pattern => {
+							#(#self_ident.__derive_where_zeroize_on_drop();)*
+						}
+					}
+				} else {
 					quote! {
 						#self_pattern => {
 							#(#self_ident.zeroize_or_on_drop();)*
 						}
 					}
 				}
-				#[cfg(not(feature = "zeroize-on-drop"))]
-				{
-					// Use unused variables.
-					let _ = fields;
+			}
+			#[cfg(not(feature = "zeroize-on-drop"))]
+			SimpleType::Struct(fields) | SimpleType::Tuple(fields) => {
+				// Use unused variables.
+				let _ = fields;
 
-					let path = util::path_from_root_and_strs(trait_.crate_(), &["Zeroize"]);
+				let path = util::path_from_root_and_strs(trait_.crate_(), &["Zeroize"]);
 
-					quote! {
-						#path::zeroize(self);
-					}
+				quote! {
+					#path::zeroize(self);
 				}
 			}
 			SimpleType::Unit(_) => TokenStream::new(),

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -6,8 +6,12 @@ fn ui() {
 	use trybuild::TestCases;
 
 	TestCases::new().compile_fail("tests/ui/*.rs");
-	#[cfg(feature = "zeroize")]
-	TestCases::new().compile_fail("tests/ui/zeroize/*.rs");
 	#[cfg(not(feature = "zeroize"))]
 	TestCases::new().compile_fail("tests/ui/not-zeroize/*.rs");
+	#[cfg(feature = "zeroize")]
+	TestCases::new().compile_fail("tests/ui/zeroize/*.rs");
+	#[cfg(all(feature = "zeroize", not(feature = "zeroize-on-drop")))]
+	TestCases::new().compile_fail("tests/ui/not-zeroize-on-drop/*.rs");
+	#[cfg(feature = "zeroize-on-drop")]
+	TestCases::new().compile_fail("tests/ui/zeroize-on-drop/*.rs");
 }

--- a/tests/ui/not-zeroize-on-drop/zeroize-on-drop.rs
+++ b/tests/ui/not-zeroize-on-drop/zeroize-on-drop.rs
@@ -1,0 +1,10 @@
+extern crate zeroize_ as zeroize;
+
+use std::marker::PhantomData;
+
+use derive_where::derive_where;
+
+#[derive_where(ZeroizeOnDrop(no_drop))]
+struct InvalidOption<T>(PhantomData<T>);
+
+fn main() {}

--- a/tests/ui/not-zeroize-on-drop/zeroize-on-drop.stderr
+++ b/tests/ui/not-zeroize-on-drop/zeroize-on-drop.stderr
@@ -1,0 +1,5 @@
+error: `ZeroizeOnDrop` doesn't support this option
+ --> tests/ui/not-zeroize-on-drop/zeroize-on-drop.rs:7:30
+  |
+7 | #[derive_where(ZeroizeOnDrop(no_drop))]
+  |                              ^^^^^^^

--- a/tests/ui/zeroize-on-drop/zeroize-on-drop.rs
+++ b/tests/ui/zeroize-on-drop/zeroize-on-drop.rs
@@ -1,0 +1,13 @@
+extern crate zeroize_ as zeroize;
+
+use std::marker::PhantomData;
+
+use derive_where::derive_where;
+
+#[derive_where(ZeroizeOnDrop(no_drop, no_drop))]
+struct DuplicateNoDrop<T>(PhantomData<T>);
+
+#[derive_where(ZeroizeOnDrop(no_drop))]
+struct NoDropNoZeroizeOnDrop<T>(T);
+
+fn main() {}

--- a/tests/ui/zeroize-on-drop/zeroize-on-drop.stderr
+++ b/tests/ui/zeroize-on-drop/zeroize-on-drop.stderr
@@ -1,0 +1,25 @@
+error: duplicate `no_drop` option
+ --> tests/ui/zeroize-on-drop/zeroize-on-drop.rs:7:39
+  |
+7 | #[derive_where(ZeroizeOnDrop(no_drop, no_drop))]
+  |                                       ^^^^^^^
+
+error[E0599]: the method `__derive_where_zeroize_on_drop` exists for mutable reference `&mut T`, but its trait bounds were not satisfied
+  --> tests/ui/zeroize-on-drop/zeroize-on-drop.rs:10:1
+   |
+10 | #[derive_where(ZeroizeOnDrop(no_drop))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `&mut T` due to unsatisfied trait bounds
+   |
+note: the following trait bounds were not satisfied:
+      `&mut T: ZeroizeOnDrop`
+      `T: ZeroizeOnDrop`
+  --> tests/ui/zeroize-on-drop/zeroize-on-drop.rs:10:1
+   |
+10 | #[derive_where(ZeroizeOnDrop(no_drop))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+   = note: this error originates in the derive macro `::derive_where::DeriveWhere` which comes from the expansion of the attribute macro `derive_where` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: the following trait defines an item `__derive_where_zeroize_on_drop`, perhaps you need to restrict type parameter `T` with it:
+   |
+11 | struct NoDropNoZeroizeOnDrop<T: <NoDropNoZeroizeOnDrop<T> as DeriveWhereAssertZeroizeOnDrop>::assert::AssertZeroizeOnDrop>(T);
+   |                               +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tests/zeroize.rs
+++ b/tests/zeroize.rs
@@ -140,6 +140,26 @@ fn deref() {
 	})
 }
 
+#[test]
+#[cfg(feature = "zeroize-on-drop")]
+fn no_drop() {
+	use zeroize::Zeroizing;
+
+	#[derive_where(ZeroizeOnDrop(no_drop))]
+	struct Test<T: Zeroize>(Zeroizing<T>);
+
+	// Test that `Drop` isn't implemented by `derive_where`.
+	impl<T: Zeroize> Drop for Test<T> {
+		fn drop(&mut self) {}
+	}
+
+	let mut test = Test(42.into());
+
+	let _ = AssertZeroizeOnDrop(&test);
+
+	util::test_drop(Test(42.into()), |test| assert_eq!(*test.0, 0))
+}
+
 mod hygiene {
 	use derive_where::derive_where;
 


### PR DESCRIPTION
This PR adds a new option to `ZeroizeOnDrop`: `no_drop`. This will implement `ZeroizeOnDrop` without implementing `Drop`. Instead, it will assert that all fields implement `ZeroizeOnDrop` (not `Zeroize`!).

The second part of this PR reworks `DeriveTrait` and moves the ownership of derive related data to the actual `TraitImpl` instead of it just being a dummy-struct to implement `TraitImpl` over. Now we have to pass in less parameters to each method and can actually use `self` to store data.