### PR TITLE
Stop Using Internal APIs

### DIFF
--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,5 +1,6 @@
-18
+19
 ≥1
+APIs
 Changelog
 CHANGELOG
 derive_bounded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `no_drop` item-level option to `ZeroizeOnDrop` which does not implement
   `Drop` but instead only asserts that every field implements `ZeroizeOnDrop`.
 
+### Fixed
+- Stop depending on unstable APIs of `zeroize` to implement `ZeroizeOnDrop`.
+
 ## [1.4.0] - 2025-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Drop` but instead only asserts that every field implements `ZeroizeOnDrop`.
 
 ### Fixed
-- Stop depending on unstable APIs of `zeroize` to implement `ZeroizeOnDrop`.
+- Stop depending on unstable APIs for `Eq` for `ZeroizeOnDrop`.
 
 ## [1.4.0] - 2025-05-01
 

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -45,16 +45,23 @@ fn struct_() -> Result<()> {
 				}
 			}
 
-			#[automatically_derived]
-			impl<T> ::core::cmp::Eq for Test<T> {
-				#[inline]
-				fn assert_receiver_is_total_eq(&self) {
-					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-					// For some reason the comparison fails without the extra space at the end.
-					let _: __AssertEq<std::marker::PhantomData<T> >;
+			const _: () = {
+				trait DeriveWhereAssertEq {
+					fn assert(&self);
 				}
-			}
+
+				impl<T> DeriveWhereAssertEq for Test<T> {
+					fn assert(&self) {
+						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+						// For some reason the comparison fails without the extra space at the end.
+						let _: __AssertEq<std::marker::PhantomData<T> >;
+					}
+				}
+			};
+
+			#[automatically_derived]
+			impl<T> ::core::cmp::Eq for Test<T> { }
 
 			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {
@@ -141,16 +148,23 @@ fn tuple() -> Result<()> {
 				}
 			}
 
-			#[automatically_derived]
-			impl<T> ::core::cmp::Eq for Test<T> {
-				#[inline]
-				fn assert_receiver_is_total_eq(&self) {
-					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-					// For some reason the comparison fails without the extra space at the end.
-					let _: __AssertEq<std::marker::PhantomData<T> >;
+			const _: () = {
+				trait DeriveWhereAssertEq {
+					fn assert(&self);
 				}
-			}
+
+				impl<T> DeriveWhereAssertEq for Test<T> {
+					fn assert(&self) {
+						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+						// For some reason the comparison fails without the extra space at the end.
+						let _: __AssertEq<std::marker::PhantomData<T> >;
+					}
+				}
+			};
+
+			#[automatically_derived]
+			impl<T> ::core::cmp::Eq for Test<T> { }
 
 			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {
@@ -287,17 +301,24 @@ fn enum_() -> Result<()> {
 				}
 			}
 
-			#[automatically_derived]
-			impl<T> ::core::cmp::Eq for Test<T> {
-				#[inline]
-				fn assert_receiver_is_total_eq(&self) {
-					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-					// For some reason the comparison fails without the extra space at the end.
-					let _: __AssertEq<std::marker::PhantomData<T> >;
-					let _: __AssertEq<std::marker::PhantomData<T> >;
+			const _: () = {
+				trait DeriveWhereAssertEq {
+					fn assert(&self);
 				}
-			}
+
+				impl<T> DeriveWhereAssertEq for Test<T> {
+					fn assert(&self) {
+						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+						// For some reason the comparison fails without the extra space at the end.
+						let _: __AssertEq<std::marker::PhantomData<T> >;
+						let _: __AssertEq<std::marker::PhantomData<T> >;
+					}
+				}
+			};
+
+			#[automatically_derived]
+			impl<T> ::core::cmp::Eq for Test<T> { }
 
 			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -235,19 +235,28 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
+			const _: () = {
+				trait DeriveWhereAssertEq {
+					fn assert(&self);
+				}
+
+				impl<T, U> DeriveWhereAssertEq for Test<T, U>
+				where T: ::core::cmp::Eq
+				{
+					fn assert(&self) {
+						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+						// For some reason the comparison fails without the extra space at the end.
+						let _: __AssertEq<T >;
+						let _: __AssertEq<std::marker::PhantomData<U> >;
+					}
+				}
+			};
+
 			#[automatically_derived]
 			impl<T, U> ::core::cmp::Eq for Test<T, U>
 			where T: ::core::cmp::Eq
-			{
-				#[inline]
-				fn assert_receiver_is_total_eq(&self) {
-					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-					// For some reason the comparison fails without the extra space at the end.
-					let _: __AssertEq<T >;
-					let _: __AssertEq<std::marker::PhantomData<U> >;
-				}
-			}
+			{ }
 
 			#[automatically_derived]
 			impl<T, U> ::core::hash::Hash for Test<T, U>
@@ -377,21 +386,32 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
+			const _: () = {
+				trait DeriveWhereAssertEq {
+					fn assert(&self);
+				}
+
+				impl<T, U, V> DeriveWhereAssertEq for Test<T, U, V>
+				where
+					T: ::core::cmp::Eq,
+					U: ::core::cmp::Eq
+				{
+					fn assert(&self) {
+						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+						// For some reason the comparison fails without the extra space at the end.
+						let _: __AssertEq<T >;
+						let _: __AssertEq<std::marker::PhantomData<(U, V)> >;
+					}
+				}
+			};
+
 			#[automatically_derived]
 			impl<T, U, V> ::core::cmp::Eq for Test<T, U, V>
 			where
 				T: ::core::cmp::Eq,
 				U: ::core::cmp::Eq
-			{
-				#[inline]
-				fn assert_receiver_is_total_eq(&self) {
-					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-					// For some reason the comparison fails without the extra space at the end.
-					let _: __AssertEq<T >;
-					let _: __AssertEq<std::marker::PhantomData<(U, V)> >;
-				}
-			}
+			{ }
 
 			#[automatically_derived]
 			impl<T, U, V> ::core::hash::Hash for Test<T, U, V>

--- a/src/test/zeroize.rs
+++ b/src/test/zeroize.rs
@@ -52,13 +52,28 @@ fn drop() -> Result<()> {
 			where T: ::zeroize::ZeroizeOnDrop
 			{
 				fn drop(&mut self) {
-					use ::zeroize::__internal::AssertZeroize;
-					use ::zeroize::__internal::AssertZeroizeOnDrop;
+					trait AssertZeroizeOnDrop {
+						fn __derive_where_zeroize_or_on_drop(self);
+					}
+
+					impl<T: ::zeroize::ZeroizeOnDrop + ?::core::marker::Sized> AssertZeroizeOnDrop for &&mut T {
+						fn __derive_where_zeroize_or_on_drop(self) {}
+					}
+
+					trait AssertZeroize {
+						fn __derive_where_zeroize_or_on_drop(&mut self);
+					}
+
+					impl<T: ::zeroize::Zeroize + ?::core::marker::Sized> AssertZeroize for T {
+						fn __derive_where_zeroize_or_on_drop(&mut self) {
+							::zeroize::Zeroize::zeroize(self);
+						}
+					}
 
 					match self {
 						Test(ref mut __field_0, ref mut __field_1) => {
-							__field_0.zeroize_or_on_drop();
-							__field_1.zeroize_or_on_drop();
+							__field_0.__derive_where_zeroize_or_on_drop();
+							__field_1.__derive_where_zeroize_or_on_drop();
 						}
 					}
 				}
@@ -92,13 +107,28 @@ fn both() -> Result<()> {
 		where T: ::zeroize::ZeroizeOnDrop
 		{
 			fn drop(&mut self) {
-				use ::zeroize::__internal::AssertZeroize;
-				use ::zeroize::__internal::AssertZeroizeOnDrop;
+				trait AssertZeroizeOnDrop {
+					fn __derive_where_zeroize_or_on_drop(self);
+				}
+
+				impl<T: ::zeroize::ZeroizeOnDrop + ?::core::marker::Sized> AssertZeroizeOnDrop for &&mut T {
+					fn __derive_where_zeroize_or_on_drop(self) {}
+				}
+
+				trait AssertZeroize {
+					fn __derive_where_zeroize_or_on_drop(&mut self);
+				}
+
+				impl<T: ::zeroize::Zeroize + ?::core::marker::Sized> AssertZeroize for T {
+					fn __derive_where_zeroize_or_on_drop(&mut self) {
+						::zeroize::Zeroize::zeroize(self);
+					}
+				}
 
 				match self {
 					Test(ref mut __field_0, ref mut __field_1) => {
-						__field_0.zeroize_or_on_drop();
-						__field_1.zeroize_or_on_drop();
+						__field_0.__derive_where_zeroize_or_on_drop();
+						__field_1.__derive_where_zeroize_or_on_drop();
 					}
 				}
 			}
@@ -188,12 +218,27 @@ fn crate_drop() -> Result<()> {
 			where T: zeroize_::ZeroizeOnDrop
 			{
 				fn drop(&mut self) {
-					use zeroize_::__internal::AssertZeroize;
-					use zeroize_::__internal::AssertZeroizeOnDrop;
+					trait AssertZeroizeOnDrop {
+						fn __derive_where_zeroize_or_on_drop(self);
+					}
+
+					impl<T: zeroize_::ZeroizeOnDrop + ?::core::marker::Sized> AssertZeroizeOnDrop for &&mut T {
+						fn __derive_where_zeroize_or_on_drop(self) {}
+					}
+
+					trait AssertZeroize {
+						fn __derive_where_zeroize_or_on_drop(&mut self);
+					}
+
+					impl<T: zeroize_::Zeroize + ?::core::marker::Sized> AssertZeroize for T {
+						fn __derive_where_zeroize_or_on_drop(&mut self) {
+							zeroize_::Zeroize::zeroize(self);
+						}
+					}
 
 					match self {
 						Test(ref mut __field_0) => {
-							__field_0.zeroize_or_on_drop();
+							__field_0.__derive_where_zeroize_or_on_drop();
 						}
 					}
 				}
@@ -285,12 +330,27 @@ fn enum_skip_drop() -> Result<()> {
 			#[automatically_derived]
 			impl <T> ::core::ops::Drop for Test<T> {
 				fn drop(&mut self) {
-					use ::zeroize::__internal::AssertZeroize;
-					use ::zeroize::__internal::AssertZeroizeOnDrop;
+					trait AssertZeroizeOnDrop {
+						fn __derive_where_zeroize_or_on_drop(self);
+					}
+
+					impl<T: ::zeroize::ZeroizeOnDrop + ?::core::marker::Sized> AssertZeroizeOnDrop for &&mut T {
+						fn __derive_where_zeroize_or_on_drop(self) {}
+					}
+
+					trait AssertZeroize {
+						fn __derive_where_zeroize_or_on_drop(&mut self);
+					}
+
+					impl<T: ::zeroize::Zeroize + ?::core::marker::Sized> AssertZeroize for T {
+						fn __derive_where_zeroize_or_on_drop(&mut self) {
+							::zeroize::Zeroize::zeroize(self);
+						}
+					}
 
 					match self {
 						Test::A(ref mut __field_0) => {
-							__field_0.zeroize_or_on_drop();
+							__field_0.__derive_where_zeroize_or_on_drop();
 						}
 						Test::B(ref mut __field_0) => { }
 					}

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -292,8 +292,8 @@ pub trait TraitImpl: Deref<Target = Trait> {
 		None
 	}
 
-	/// Trait to implement. Only used for [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html)
-	/// because it implements [`Drop`] and not itself.
+	/// Trait to implement. Only used by [`Eq`] and
+	/// [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html).
 	fn impl_item(
 		&self,
 		imp: &ImplGenerics<'_>,


### PR DESCRIPTION
This changes the implementation of `Eq` to not use `Eq::assert_receiver_is_total_eq()` and the implementation of `ZeroizeOnDrop` to not use `zeroite::__internal`. Both are `doc(hidden)` and therefor unstable APIs.

Resolves #115.