### PR TITLE
Compilation errors when enabling the `serde` feature

### DIFF
--- a/tests/weird.rs
+++ b/tests/weird.rs
@@ -1,0 +1,36 @@
+use core::fmt::{Debug};
+
+use serde_::{Serialize, Deserialize};
+
+pub trait Protocol<Id> {
+    type ProtocolError: ProtocolError<Id>;
+}
+
+pub trait ProtocolError<Id>: Debug + Clone + Serialize + for<'de> Deserialize<'de> {}
+
+pub trait ChainedProtocol<Id>: 'static + Debug {
+    type Protocol1: Protocol<Id>;
+}
+
+#[derive_where::derive_where(Debug, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(crate = "serde_")]
+#[serde(bound(serialize = "
+    <C::Protocol1 as Protocol<Id>>::ProtocolError: Serialize,
+"))]
+#[serde(bound(deserialize = "
+    <C::Protocol1 as Protocol<Id>>::ProtocolError: for<'x> Deserialize<'x>,
+"))]
+pub enum ChainedProtocolError<Id, C>
+where
+    C: ChainedProtocol<Id>,
+{
+    Protocol1(<C::Protocol1 as Protocol<Id>>::ProtocolError),
+}
+
+impl<Id, C> ProtocolError<Id> for ChainedProtocolError<Id, C>
+where
+    C: ChainedProtocol<Id>,
+{
+
+}


### PR DESCRIPTION
In my crate I was previously using `derive-where` for `Debug` and `Clone`, and tried to upgrade to 1.5 to use the new `serde` derivation as well. The test in the PR is a simplified extract from my code. The `serde(bound)` stuff is what I was hoping to get rid of.

The problem is, when just enabling the `serde` feature of `derive-where`, without any further changes, this code stops compiling. In this PR, you can see that just running `cargo build --tests` compiles fine, but `cargo build --tests --features serde` fails. The errors are:
```
error: Found unused `#[serde(...)]`
  --> tests/weird.rs:19:1
   |
17 | #[serde(crate = "serde_")]
   | ^
```
(in the original code, since there's no need for `serde(crate)`, it's the same error but about `serde(bound)`)
```
error[E0277]: the trait bound `ChainedProtocolError<Id, C>: Clone` is not satisfied
  --> tests/weird.rs:33:35
   |
31 | impl<Id, C> ProtocolError<Id> for ChainedProtocolError<Id, C>
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `ChainedProtocolError<Id, C>`
```
and
```
error[E0277]: `ChainedProtocolError<Id, C>` doesn't implement `Debug`
  --> tests/weird.rs:33:35
   |
31 | impl<Id, C> ProtocolError<Id> for ChainedProtocolError<Id, C>
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ChainedProtocolError<Id, C>` cannot be formatted using `{:?}`
```

Not sure what is happening here. I am going to try and find a workaround for my code. 

*Update:* removing `serde(bound)` and switching to `derive-where` for `serde` fixes the compilation. 

*Update:* Could this be cause by `serde` attribute being processed by `derive-where` even if `Serialize/Deserialize` are not derived with it?