### PR TITLE
don't generate extra `impl` for `Eq` assertions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,20 +648,7 @@ fn generate_impl(
 	let body = generate_body(derive_where, trait_, item, generics);
 
 	let ident = item.ident();
-	let mut output = trait_.impl_item(crate_, full_item, imp, ident, ty, &where_clause, body);
-
-	if let Some((path, body)) = trait_.additional_impl() {
-		output.extend(quote! {
-			#[automatically_derived]
-			impl #imp #path for #ident #ty
-			#where_clause
-			{
-				#body
-			}
-		})
-	}
-
-	output
+	trait_.impl_item(crate_, full_item, imp, ident, ty, &where_clause, body)
 }
 
 /// Generate implementation method body for a [`Trait`].

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -45,23 +45,15 @@ fn struct_() -> Result<()> {
 				}
 			}
 
-			const _: () = {
-				trait DeriveWhereAssertEq {
-					fn assert(&self);
-				}
-
-				impl<T> DeriveWhereAssertEq for Test<T> {
-					fn assert(&self) {
-						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-						// For some reason the comparison fails without the extra space at the end.
-						let _: __AssertEq<std::marker::PhantomData<T> >;
-					}
-				}
-			};
-
 			#[automatically_derived]
-			impl<T> ::core::cmp::Eq for Test<T> { }
+			impl<T> ::core::cmp::Eq for Test<T> {
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// place extra space to avoid token being printed as `>>`
+					let _: __AssertEq<std::marker::PhantomData<T> >;
+				}
+			}
 
 			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {
@@ -148,23 +140,15 @@ fn tuple() -> Result<()> {
 				}
 			}
 
-			const _: () = {
-				trait DeriveWhereAssertEq {
-					fn assert(&self);
-				}
-
-				impl<T> DeriveWhereAssertEq for Test<T> {
-					fn assert(&self) {
-						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-						// For some reason the comparison fails without the extra space at the end.
-						let _: __AssertEq<std::marker::PhantomData<T> >;
-					}
-				}
-			};
-
 			#[automatically_derived]
-			impl<T> ::core::cmp::Eq for Test<T> { }
+			impl<T> ::core::cmp::Eq for Test<T> {
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// place extra space to avoid token being printed as `>>`
+					let _: __AssertEq<std::marker::PhantomData<T> >;
+				}
+			}
 
 			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {
@@ -301,24 +285,16 @@ fn enum_() -> Result<()> {
 				}
 			}
 
-			const _: () = {
-				trait DeriveWhereAssertEq {
-					fn assert(&self);
-				}
-
-				impl<T> DeriveWhereAssertEq for Test<T> {
-					fn assert(&self) {
-						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-						// For some reason the comparison fails without the extra space at the end.
-						let _: __AssertEq<std::marker::PhantomData<T> >;
-						let _: __AssertEq<std::marker::PhantomData<T> >;
-					}
-				}
-			};
-
 			#[automatically_derived]
-			impl<T> ::core::cmp::Eq for Test<T> { }
+			impl<T> ::core::cmp::Eq for Test<T> {
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					// place extra space to avoid token being printed as `>>`
+					let _: __AssertEq<std::marker::PhantomData<T> >;
+					let _: __AssertEq<std::marker::PhantomData<T> >;
+				}
+			}
 
 			#[automatically_derived]
 			impl<T> ::core::hash::Hash for Test<T> {

--- a/src/test/bound.rs
+++ b/src/test/bound.rs
@@ -235,28 +235,17 @@ fn check_trait_bounds() -> Result<()> {
 				}
 			}
 
-			const _: () = {
-				trait DeriveWhereAssertEq {
-					fn assert(&self);
-				}
-
-				impl<T, U> DeriveWhereAssertEq for Test<T, U>
-				where T: ::core::cmp::Eq
-				{
-					fn assert(&self) {
-						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-						// For some reason the comparison fails without the extra space at the end.
-						let _: __AssertEq<T >;
-						let _: __AssertEq<std::marker::PhantomData<U> >;
-					}
-				}
-			};
-
 			#[automatically_derived]
 			impl<T, U> ::core::cmp::Eq for Test<T, U>
 			where T: ::core::cmp::Eq
-			{ }
+			{
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+
+					let _: __AssertEq<T>;
+					let _: __AssertEq<std::marker::PhantomData<U> >;
+				}
+			}
 
 			#[automatically_derived]
 			impl<T, U> ::core::hash::Hash for Test<T, U>
@@ -386,32 +375,19 @@ fn check_multiple_trait_bounds() -> Result<()> {
 				}
 			}
 
-			const _: () = {
-				trait DeriveWhereAssertEq {
-					fn assert(&self);
-				}
-
-				impl<T, U, V> DeriveWhereAssertEq for Test<T, U, V>
-				where
-					T: ::core::cmp::Eq,
-					U: ::core::cmp::Eq
-				{
-					fn assert(&self) {
-						struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
-
-						// For some reason the comparison fails without the extra space at the end.
-						let _: __AssertEq<T >;
-						let _: __AssertEq<std::marker::PhantomData<(U, V)> >;
-					}
-				}
-			};
-
 			#[automatically_derived]
 			impl<T, U, V> ::core::cmp::Eq for Test<T, U, V>
 			where
 				T: ::core::cmp::Eq,
 				U: ::core::cmp::Eq
-			{ }
+			{
+				fn assert_receiver_is_total_eq(&self) {
+					struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
+					let _: __AssertEq<T>;
+					// place extra space to avoid token being printed as `>>`
+					let _: __AssertEq<std::marker::PhantomData<(U, V)> >;
+				}
+			}
 
 			#[automatically_derived]
 			impl<T, U, V> ::core::hash::Hash for Test<T, U, V>

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -345,11 +345,6 @@ pub trait TraitImpl: Deref<Target = Trait> {
 	/// Returns fully qualified [`Path`] for this trait.
 	fn path(&self) -> Path;
 
-	/// Additional implementation to add for this [`Trait`].
-	fn additional_impl(&self) -> Option<(Path, TokenStream)> {
-		None
-	}
-
 	/// Trait to implement. Only used by [`Eq`] and
 	/// [`ZeroizeOnDrop`](https://docs.rs/zeroize/latest/zeroize/trait.ZeroizeOnDrop.html).
 	#[allow(clippy::too_many_arguments)]

--- a/src/trait_/eq.rs
+++ b/src/trait_/eq.rs
@@ -1,10 +1,10 @@
 //! [`Eq`](trait@std::cmp::Eq) implementation.
 
-use std::{borrow::Cow, ops::Deref};
+use std::ops::Deref;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{DeriveInput, Ident, ImplGenerics, Path, TypeGenerics, WhereClause};
+use syn::Path;
 
 use crate::{util, Data, DeriveTrait, DeriveWhere, Item, SplitGenerics, Trait, TraitImpl};
 
@@ -24,35 +24,6 @@ impl TraitImpl for Eq {
 		util::path_from_strs(&["core", "cmp", "Eq"])
 	}
 
-	fn additional_impl(&self) -> Option<(Path, TokenStream)> {
-		Some((self.path(), quote! {}))
-	}
-
-	fn impl_item(
-		&self,
-		_: Option<&Path>,
-		_: &DeriveInput,
-		imp: &ImplGenerics<'_>,
-		ident: &Ident,
-		ty: &TypeGenerics<'_>,
-		where_clause: &Option<Cow<'_, WhereClause>>,
-		body: TokenStream,
-	) -> TokenStream {
-		quote! {
-			const _: () = {
-				trait DeriveWhereAssertEq {
-					fn assert(&self);
-				}
-
-				impl #imp DeriveWhereAssertEq for #ident #ty
-				#where_clause
-				{
-					#body
-				}
-			};
-		}
-	}
-
 	fn build_signature(
 		&self,
 		_derive_where: &DeriveWhere,
@@ -61,7 +32,7 @@ impl TraitImpl for Eq {
 		body: &TokenStream,
 	) -> TokenStream {
 		quote! {
-			fn assert(&self) {
+			fn assert_receiver_is_total_eq(&self) {
 				struct __AssertEq<__T: ::core::cmp::Eq + ?::core::marker::Sized>(::core::marker::PhantomData<__T>);
 
 				#body


### PR DESCRIPTION
`Eq` already has a method `assert_receiver_is_total_eq` that allows you to put asserts in. This PR makes it so we use that instead of generating a new trait and impl every time (which could be a lot).

This is also a cleanup because apparently `additional_impl` is only used by `Eq` (and arguably quite confusing as `additional_impl` is used to generate the `Eq` impl while the "main" `impl` was the extra impl) so we can remove that now.

generating a `struct __AssertEq` each time is still a little wasteful, but given that `derive-where` is a single crate (so no "normal" support crate to share types) it might be unavoidable.

