### PR TITLE
Update alternative section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@
 //! test.zeroize();
 //! assert_eq!(test.0, 1);
 //!
-//! // WIll call the `Zeroize::zeroize` method.
+//! // Will call the `Zeroize::zeroize` method.
 //! Zeroize::zeroize(&mut test);
 //! assert_eq!(test.0, 0);
 //! # }
@@ -357,9 +357,8 @@
 //!
 //! # Alternatives
 //!
-//! - [derivative](https://crates.io/crates/derivative) [![Crates.io](https://img.shields.io/crates/v/derivative.svg)](https://crates.io/crates/derivative)
-//!   is a great alternative with many options. Notably it doesn't support
-//!   `no_std` and requires an extra `#[derive(Derivative)]` to use.
+//! - [derive_more](https://crates.io/crates/derive_more) [![Crates.io](https://img.shields.io/crates/v/derive_more.svg)](https://crates.io/crates/derive_more)
+//!   derives traits with bounds based on field types instead of parameters. It does not allow giving custom bounds.
 //! - [derive_bounded](https://crates.io/crates/derive_bounded) [![Crates.io](https://img.shields.io/crates/v/derive_bounded.svg)](https://crates.io/crates/derive_bounded)
 //!   is a new alternative still in development.
 //!


### PR DESCRIPTION
There's a RUSTSEC unmaintained notice for `derivative` ([RUSTSEC-2024-0388](https://rustsec.org/advisories/RUSTSEC-2024-0388.html)). The new crate added to the alternatives section is one of the options also referenced in this note.